### PR TITLE
feat: Google Analytics modularization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,8 @@
     "prefer-stable": true,
     "require-dev": {
         "orchestra/testbench": "*"
+    },
+    "suggest": {
+        "google/analytics-data": "Required for Google Analytics Data API (GoogleAnalyticsService)"
     }
 }

--- a/config/analytics.php
+++ b/config/analytics.php
@@ -1,0 +1,192 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Analytics Enabled
+    |--------------------------------------------------------------------------
+    |
+    | Enable or disable page view logging. When disabled, no page views
+    | will be logged to the database.
+    |
+    */
+
+    'enabled' => env('ANALYTICS_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Page View Log Model
+    |--------------------------------------------------------------------------
+    |
+    | The model class used for page view logging. Override this if you
+    | need to use a custom model with additional fields or behavior.
+    |
+    */
+
+    'page-view-log-model' => \Condoedge\Utils\Models\Analytics\PageViewLog::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Log API Requests
+    |--------------------------------------------------------------------------
+    |
+    | By default, API requests are not logged. Set this to true to log
+    | API endpoint requests (routes starting with 'api/*').
+    |
+    */
+
+    'log_api_requests' => env('ANALYTICS_LOG_API_REQUESTS', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Excluded Paths
+    |--------------------------------------------------------------------------
+    |
+    | List of URL patterns to exclude from page view logging.
+    | Supports wildcards (e.g., 'admin/*', '_debugbar/*').
+    |
+    */
+
+    'excluded_paths' => [
+        '_debugbar/*',
+        'telescope/*',
+        'horizon/*',
+        'livewire/*',
+        '*/message',
+        'admin/analytics/*', // Don't log analytics pages themselves
+        '*.js',
+        '*.css',
+        '*.map',
+        '*.ico',
+        '*.png',
+        '*.jpg',
+        '*.jpeg',
+        '*.gif',
+        '*.svg',
+        '*.woff',
+        '*.woff2',
+        '*.ttf',
+        '*.eot',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Excluded Routes
+    |--------------------------------------------------------------------------
+    |
+    | List of route names to exclude from page view logging.
+    |
+    */
+
+    'excluded_routes' => [
+        'debugbar.*',
+        'telescope.*',
+        'horizon.*',
+        'livewire.message',
+        'livewire.upload-file',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Dashboard Settings
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for the Google Analytics Dashboard.
+    |
+    */
+
+    'dashboard' => [
+        // Number of days to show by default
+        'default_date_range' => 30,
+
+        // Number of items per page in logs table
+        'logs_per_page' => 50,
+
+        // Refresh interval for realtime feed (in seconds)
+        'realtime_refresh_interval' => 30,
+
+        // Cache duration for dashboard metrics (in minutes)
+        'cache_duration' => 5,
+
+        // Top pages limit
+        'top_pages_limit' => 10,
+
+        // Top users limit
+        'top_users_limit' => 10,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Data Retention
+    |--------------------------------------------------------------------------
+    |
+    | How long to keep page view logs in the database.
+    | Older logs will be automatically deleted.
+    |
+    | Set to null to keep logs indefinitely.
+    | Set to a number to keep logs for that many days.
+    |
+    */
+
+    'data_retention_days' => env('ANALYTICS_DATA_RETENTION_DAYS', 90),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Privacy Settings
+    |--------------------------------------------------------------------------
+    |
+    | Privacy-related settings for analytics.
+    |
+    */
+
+    'privacy' => [
+        // Anonymize IP addresses (last octet set to 0)
+        'anonymize_ip' => env('ANALYTICS_ANONYMIZE_IP', false),
+
+        // Hash user IDs before storing
+        'hash_user_ids' => env('ANALYTICS_HASH_USER_IDS', true),
+
+        // Respect Do Not Track browser setting
+        'respect_do_not_track' => env('ANALYTICS_RESPECT_DNT', false),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Performance Settings
+    |--------------------------------------------------------------------------
+    |
+    | Performance-related settings for analytics logging.
+    |
+    */
+
+    'performance' => [
+        // Log page views asynchronously (doesn't block requests)
+        'async_logging' => env('ANALYTICS_ASYNC_LOGGING', true),
+
+        // Batch insert multiple logs at once (for high-traffic sites)
+        'batch_logging' => env('ANALYTICS_BATCH_LOGGING', false),
+
+        // Batch size (number of logs to batch before inserting)
+        'batch_size' => env('ANALYTICS_BATCH_SIZE', 100),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Chart Colors
+    |--------------------------------------------------------------------------
+    |
+    | Colors used in dashboard charts.
+    |
+    */
+
+    'chart_colors' => [
+        'primary' => '#3B82F6',     // Blue
+        'success' => '#10B981',     // Green
+        'warning' => '#F59E0B',     // Orange
+        'danger' => '#EF4444',      // Red
+        'info' => '#06B6D4',        // Cyan
+        'secondary' => '#6B7280',   // Gray
+    ],
+
+];

--- a/config/services.php
+++ b/config/services.php
@@ -32,4 +32,17 @@ return [
         'base_url' => env('GEOCODIO_BASE_URL', 'https://api.geocod.io/v1.9'),
         'api_key' => env('GEOCODIO_API_KEY'),
     ],
+
+    'google_analytics' => [
+        'enabled' => env('GOOGLE_ANALYTICS_ENABLED', false),
+        'measurement_id' => env('GOOGLE_ANALYTICS_MEASUREMENT_ID'),
+        'property_id' => env('GOOGLE_ANALYTICS_PROPERTY_ID'),
+        'credentials_path' => env('GOOGLE_ANALYTICS_CREDENTIALS_PATH',
+            storage_path('app/google/analytics-credentials.json')),
+    ],
+
+    'google_tag_manager' => [
+        'enabled' => env('GTM_ENABLED', false),
+        'container_id' => env('GTM_CONTAINER_ID'),
+    ],
 ];

--- a/database/migrations/2026_02_05_103155_create_page_view_logs_table.php
+++ b/database/migrations/2026_02_05_103155_create_page_view_logs_table.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('page_view_logs', function (Blueprint $table) {
+            $table->id();
+
+            // User identification
+            $table->foreignId('user_id')->nullable()->constrained('users')->onDelete('set null');
+            $table->string('user_id_hashed', 64)->nullable()->index(); // SHA-256 hash for privacy
+
+            // Team context (multi-tenancy)
+            $table->unsignedBigInteger('team_id')->nullable()->index();
+            if (Schema::hasTable('teams')) {
+                $table->foreign('team_id')->references('id')->on('teams')->onDelete('set null');
+            }
+            $table->string('team_level', 20)->nullable()->index(); // MAIN, DISTRICT, GROUP, UNIT
+            $table->string('user_role', 50)->nullable(); // Role name within team
+            $table->string('user_type', 20)->nullable(); // SCOUT, LEADER, VOLUNTEER, PARENT
+
+            // Page information
+            $table->string('page_url', 500)->index();
+            $table->string('page_title', 255)->nullable();
+            $table->string('http_method', 10)->default('GET'); // GET, POST, PUT, DELETE
+            $table->json('query_params')->nullable(); // URL query parameters
+
+            // Request metadata
+            $table->string('referer_url', 500)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->string('ip_address', 45)->nullable(); // Supports IPv6
+            $table->string('session_id', 100)->nullable()->index();
+
+            // User flags
+            $table->boolean('is_authenticated')->default(false)->index();
+            $table->boolean('is_super_admin')->default(false)->index();
+
+            // Environment
+            $table->string('environment', 20)->default('production'); // production, staging, local
+
+            // Timestamp
+            $table->timestamp('viewed_at')->index();
+            $table->timestamps();
+
+            // Composite indexes for common queries
+            $table->index(['user_id', 'viewed_at']);
+            $table->index(['team_id', 'viewed_at']);
+            $table->index(['team_level', 'viewed_at']);
+            $table->index(['is_authenticated', 'viewed_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('page_view_logs');
+    }
+};

--- a/docs/google-analytics-modularization.txt
+++ b/docs/google-analytics-modularization.txt
@@ -1,0 +1,418 @@
+# Google Analytics Modularization — Plan d'implementation
+
+## Contexte
+
+**Branche:** `google-analytics-v2`
+**Objectif:** Deplacer le code Google Analytics reutilisable de l'application SISC vers le package `condoedge/utils`, pour permettre la reutilisation dans d'autres projets (ex: Coolecto).
+
+**Probleme initial:** Tout le code GA4 (services, middleware, listeners, model, migration, vues Blade) vivait dans `app/` avec des dependances directes vers des fonctions SISC (`currentTeam()`, `currentTeamRole()`, `isSuperAdmin()`).
+
+**Solution:** Utiliser les safe helpers existants dans utils (`safeCurrentTeam()`, `safeIsSuperAdmin()`, etc.) + en creer un nouveau (`safeCurrentTeamRole()`), et utiliser les facades `TeamModel`/`UserModel` pour les relations Eloquent.
+
+---
+
+## Architecture avant/apres
+
+### AVANT (tout dans SISC app/)
+
+```
+app/
+├── Http/Middleware/LogPageView.php          → currentTeam(), isSuperAdmin()
+├── Listeners/
+│   ├── TrackUserLogin.php                   → currentTeam(), App\Services\GoogleTagManager
+│   └── TrackUserLogout.php                  → App\Services\GoogleTagManager
+├── Models/Analytics/PageViewLog.php         → App\Models\Teams\Team, App\Models\User
+├── Services/
+│   ├── GoogleAnalyticsService.php           → Zero dep SISC (GA4 Data API)
+│   └── GoogleTagManager.php                 → currentTeam(), currentTeamRole(), isSuperAdmin()
+config/analytics.php
+database/migrations/2026_02_05_...php        → FK directe vers teams
+resources/views/
+├── layouts/google-analytics.blade.php       → App\Services\GoogleTagManager
+└── kompo/body-top.blade.php                 → config GTM
+```
+
+### APRES (reutilisable dans utils/)
+
+```
+packages/condoedge/utils/
+├── config/
+│   ├── analytics.php                        → +page-view-log-model key
+│   └── services.php                         → +google_analytics, +google_tag_manager
+├── database/migrations/
+│   └── 2026_02_05_...php                    → FK conditionnelle (Schema::hasTable)
+├── resources/views/analytics/
+│   ├── google-analytics.blade.php           → Condoedge\Utils\Services\Analytics\GoogleTagManager
+│   └── body-top.blade.php                   → config GTM (inchange)
+├── src/
+│   ├── Helpers/auth.php                     → +safeCurrentTeamRole()
+│   ├── Http/Middleware/LogPageView.php       → safe helpers + model dynamique via config
+│   ├── Listeners/
+│   │   ├── TrackUserLogin.php               → safe helpers + fallback chains
+│   │   └── TrackUserLogout.php              → namespace change uniquement
+│   ├── Models/Analytics/PageViewLog.php     → BelongsToUserTrait + TeamModel facade
+│   ├── Services/Analytics/
+│   │   ├── GoogleAnalyticsService.php       → namespace change uniquement
+│   │   └── GoogleTagManager.php             → safe helpers + fallback chains
+│   └── CondoedgeUtilsServiceProvider.php    → config, singleton, listeners
+└── composer.json                            → +suggest google/analytics-data
+```
+
+---
+
+## Detail des modifications par phase
+
+### Phase 0 — Corrections prealables
+
+#### 0.1: `.gitignore`
+**Probleme:** Les fichiers Laravel core (`Kernel.php`, `AppServiceProvider.php`, `EventServiceProvider.php`) etaient ajoutes au `.gitignore` par erreur.
+
+**Correction:** Retrait des 2 lignes erronees:
+```diff
+- app/Providers/AppServiceProvider.php
+- app/Http/Kernel.php
+```
+
+#### 0.2: Nouveau helper `safeCurrentTeamRole()`
+**Fichier:** `packages/condoedge/utils/src/Helpers/auth.php`
+
+```php
+if (!function_exists('safeCurrentTeamRole')) {
+    function safeCurrentTeamRole()
+    {
+        return secureCall('currentTeamRole') ?? null;
+    }
+}
+```
+
+Ce helper suit le meme pattern que `safeCurrentTeam()` et `safeIsSuperAdmin()`: il utilise `secureCall()` qui verifie l'existence de la fonction avant de l'appeler et catch les exceptions.
+
+---
+
+### Phase 1 — Configuration (utils)
+
+#### 1.1: `packages/condoedge/utils/config/analytics.php`
+Copie du `config/analytics.php` SISC + ajout de la cle `page-view-log-model`:
+```php
+'page-view-log-model' => \Condoedge\Utils\Models\Analytics\PageViewLog::class,
+```
+Permet a une app consommatrice de surcharger le model (ex: ajouter des colonnes specifiques).
+
+#### 1.2: `packages/condoedge/utils/config/services.php`
+Ajout de 2 blocs apres `geocodio`:
+```php
+'google_analytics' => [
+    'enabled' => env('GOOGLE_ANALYTICS_ENABLED', false),
+    'measurement_id' => env('GOOGLE_ANALYTICS_MEASUREMENT_ID'),
+    'property_id' => env('GOOGLE_ANALYTICS_PROPERTY_ID'),
+    'credentials_path' => env('GOOGLE_ANALYTICS_CREDENTIALS_PATH',
+        storage_path('app/google/analytics-credentials.json')),
+],
+'google_tag_manager' => [
+    'enabled' => env('GTM_ENABLED', false),
+    'container_id' => env('GTM_CONTAINER_ID'),
+],
+```
+Via `mergeConfigFrom`, ces valeurs servent de defaults. L'app SISC les override avec son propre `config/services.php`.
+
+#### 1.3: Enregistrement dans le ServiceProvider
+- `loadConfig()`: ajout de `'analytics' => __DIR__.'/../config/analytics.php'`
+- `publishes()`: ajout de `analytics.php => config_path('analytics.php')` dans le tag `kompo-utils-config`
+
+---
+
+### Phase 2 — Model, Migration, Services (utils)
+
+#### 2.1: `PageViewLog` model
+**Namespace:** `Condoedge\Utils\Models\Analytics`
+
+**Strategie pour les relations:**
+- **User:** Utilise `BelongsToUserTrait` (fournit `user()` via `UserModel::getClass()`)
+- **Team:** Relation manuelle via `TeamModel::getClass()` (ne pas utiliser `BelongsToTeamTrait` car son `scopeForTeam` a une logique differente avec `getAllChildrenRawSolution`)
+
+```php
+use Condoedge\Utils\Facades\TeamModel;
+use Condoedge\Utils\Models\Traits\BelongsToUserTrait;
+
+class PageViewLog extends Model
+{
+    use BelongsToUserTrait;
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(TeamModel::getClass());
+    }
+
+    // scopeForTeam accepte object ou scalar (pas de type hint specifique)
+    public function scopeForTeam(Builder $query, $team): Builder
+    {
+        $teamId = is_object($team) ? $team->id : $team;
+        return $query->where('team_id', $teamId);
+    }
+}
+```
+
+#### 2.2: Migration
+**Changement cle:** La FK `team_id` est conditionnelle:
+```php
+$table->unsignedBigInteger('team_id')->nullable()->index();
+if (Schema::hasTable('teams')) {
+    $table->foreign('team_id')->references('id')->on('teams')->onDelete('set null');
+}
+```
+La migration est auto-chargee par le `loadMigrationsFrom` existant dans le ServiceProvider (gate par `config('kompo-utils.load-migrations')`).
+
+#### 2.3: `GoogleAnalyticsService`
+Namespace change uniquement (`App\Services` → `Condoedge\Utils\Services\Analytics`). Zero dependance SISC — utilise uniquement la Google Analytics Data API.
+
+Enregistre comme singleton:
+```php
+$this->app->singleton(GoogleAnalyticsService::class, function ($app) {
+    return new GoogleAnalyticsService();
+});
+```
+
+#### 2.4: `GoogleTagManager`
+**Namespace:** `Condoedge\Utils\Services\Analytics`
+
+**Modifications dans `getUserData()`:**
+
+| Avant (SISC) | Apres (utils) |
+|---|---|
+| `function_exists('currentTeam') && currentTeam()` | `$team = safeCurrentTeam(); if ($team)` |
+| `function_exists('currentTeamRole') && currentTeamRole()` | `$teamRole = safeCurrentTeamRole(); if ($teamRole)` |
+| `function_exists('isSuperAdmin') ? isSuperAdmin() : false` | `safeIsSuperAdmin()` |
+| `$team->team_name` | `$team->team_name ?? ($team->name ?? null)` |
+| `$team->team_level->value` | `$team->team_level->value ?? ($team->level ?? 'unknown')` |
+| `$teamRole->roleRelation->name` | `$teamRole->roleRelation->name ?? ($teamRole->role->name ?? 'unknown')` |
+| try/catch bloc autour du team context | Retire (safe helpers gerent deja les exceptions) |
+
+**Pourquoi les fallback chains?** Differentes apps peuvent avoir des noms de proprietes differents pour le team model (`team_name` vs `name`, `team_level` enum vs `level` string).
+
+---
+
+### Phase 3 — Middleware, Listeners, Views (utils)
+
+#### 3.1: `LogPageView` middleware
+**Namespace:** `Condoedge\Utils\Http\Middleware`
+
+**Modifications:**
+
+| Avant (SISC) | Apres (utils) |
+|---|---|
+| `use App\Models\Analytics\PageViewLog` | Model dynamique via config |
+| `use App\Services\GoogleTagManager` | `use Condoedge\Utils\Services\Analytics\GoogleTagManager` |
+| `function_exists('currentTeam') ? currentTeam() : null` | `safeCurrentTeam()` |
+| `function_exists('currentTeamRole') ? currentTeamRole() : null` | `safeCurrentTeamRole()` |
+| `$team?->team_level?->value` | `$team?->team_level?->value ?? ($team?->level ?? null)` |
+| `$teamRole?->role?->name` | `$teamRole?->roleRelation?->name ?? ($teamRole?->role?->name ?? null)` |
+| `function_exists('isSuperAdmin') ? isSuperAdmin() : false` | `safeIsSuperAdmin()` |
+| `PageViewLog::create($logData)` | `$modelClass::create($logData)` (via config) |
+
+**Resolution dynamique du model:**
+```php
+$modelClass = config('analytics.page-view-log-model',
+    \Condoedge\Utils\Models\Analytics\PageViewLog::class);
+$modelClass::create($logData);
+```
+
+#### 3.2: `TrackUserLogin` listener
+- Import: `Condoedge\Utils\Services\Analytics\GoogleTagManager`
+- `function_exists('currentTeam') && currentTeam()` → `$team = safeCurrentTeam(); if ($team)`
+- `$team->team_level->value` → `$team->team_level->value ?? ($team->level ?? 'unknown')`
+
+#### 3.3: `TrackUserLogout` listener
+- Namespace + import change uniquement. Zero dependance SISC.
+
+#### 3.4: Vues Blade
+- **`kompo-utils::analytics.google-analytics`**: Remplace `\App\Services\GoogleTagManager::getUserData()` par `\Condoedge\Utils\Services\Analytics\GoogleTagManager::getUserData()`
+- **`kompo-utils::analytics.body-top`**: Copie directe (zero dep SISC)
+
+#### 3.5: Enregistrement des listeners dans le ServiceProvider
+```php
+protected function registerAnalyticsListeners(): void
+{
+    if (!config('services.google_analytics.measurement_id')) {
+        return;
+    }
+
+    Event::listen(Login::class, TrackUserLogin::class);
+    Event::listen(Logout::class, TrackUserLogout::class);
+}
+```
+La condition est `measurement_id` (pas `enabled`), car `GoogleTagManager::isEnabled()` verifie le measurement_id.
+
+Appele depuis `boot()` apres `registerComplianceNotificationSystem()`.
+
+---
+
+### Phase 4 — Composer
+
+`packages/condoedge/utils/composer.json` — ajout:
+```json
+"suggest": {
+    "google/analytics-data": "Required for Google Analytics Data API (GoogleAnalyticsService)"
+}
+```
+En `suggest` et non `require` car le GoogleAnalyticsService (API server-side) est optionnel. Le tracking GA4 client-side (gtag.js) ne necessite pas cette lib.
+
+---
+
+### Phase 5 — Wiring SISC
+
+#### 5.1: `app/Http/Kernel.php`
+```diff
+- \App\Http\Middleware\LogPageView::class,
++ \Condoedge\Utils\Http\Middleware\LogPageView::class,
+```
+
+#### 5.2: `app/Providers/EventServiceProvider.php`
+Retrait des blocs Login/Logout (maintenant geres par le ServiceProvider de utils):
+```diff
+- use Illuminate\Auth\Events\Login;
+- use Illuminate\Auth\Events\Logout;
+  ...
+- Login::class => [\App\Listeners\TrackUserLogin::class],
+- Logout::class => [\App\Listeners\TrackUserLogout::class],
+```
+
+#### 5.3: `resources/views/layouts/app.blade.php`
+```diff
+- @include('layouts.google-analytics')
++ @include('kompo-utils::analytics.google-analytics')
+```
+
+#### 5.4: `resources/views/layouts/dashboard.blade.php`
+```diff
+- <meta name="current-team-id" content="{{ currentTeam()?->id }}">
+- <meta name="current-team-level" content="{{ currentTeam()?->level }}">
++ <meta name="current-team-id" content="{{ safeCurrentTeamId() }}">
++ <meta name="current-team-level" content="{{ safeCurrentTeam()?->team_level?->value ?? safeCurrentTeam()?->level }}">
+```
+
+#### 5.5: Fichiers supprimes de SISC (10 fichiers)
+| Fichier | Raison |
+|---|---|
+| `app/Services/GoogleAnalyticsService.php` | Deplace vers utils |
+| `app/Services/GoogleTagManager.php` | Deplace vers utils |
+| `app/Http/Middleware/LogPageView.php` | Deplace vers utils |
+| `app/Listeners/TrackUserLogin.php` | Deplace vers utils |
+| `app/Listeners/TrackUserLogout.php` | Deplace vers utils |
+| `app/Models/Analytics/PageViewLog.php` | Deplace vers utils |
+| `app/Models/Analytics/` (dossier) | Vide apres suppression |
+| `config/analytics.php` | Deplace vers utils |
+| `database/migrations/2026_02_05_...php` | Deplace vers utils |
+| `resources/views/layouts/google-analytics.blade.php` | Deplace vers utils |
+| `resources/views/kompo/body-top.blade.php` | Deplace vers utils |
+
+#### 5.6-5.9: Fichiers inchanges
+- `config/services.php` (SISC) — garde ses overrides, `mergeConfigFrom` de utils fournit les defaults
+- `.env.example` — pas d'ajout de nouvelles vars
+- `ga4-activity-tracker.js` + `webpack.mix.js` — restent dans SISC (mapping URL→module specifique)
+- `public/js/`, `public/css/` — artefacts de build, inchanges
+
+---
+
+### Phase 6 — Verification
+
+#### Grep pour references obsoletes
+Aucune reference trouvee dans le code source pour:
+- `App\Services\GoogleTagManager`
+- `App\Services\GoogleAnalyticsService`
+- `App\Models\Analytics\PageViewLog`
+- `App\Listeners\TrackUserLogin` / `TrackUserLogout`
+- `App\Http\Middleware\LogPageView`
+- `layouts.google-analytics` / `kompo.body-top`
+
+Seules references: cache Blade compile (`storage/framework/views/`) — auto-regenere.
+
+#### Coherence des config keys
+| Config key | Utilise par |
+|---|---|
+| `services.google_analytics.measurement_id` | GoogleTagManager::isEnabled(), blade view, ServiceProvider |
+| `services.google_analytics.property_id` | GoogleAnalyticsService |
+| `services.google_analytics.credentials_path` | GoogleAnalyticsService |
+| `services.google_tag_manager.*` | body-top.blade.php uniquement |
+| `analytics.enabled` | LogPageView middleware |
+| `analytics.excluded_paths` | LogPageView middleware |
+| `analytics.page-view-log-model` | LogPageView middleware |
+
+---
+
+## Tests en navigateur
+
+**Resultats (Chrome, http://127.0.0.1:8000/dashboard):**
+
+| Check | Resultat |
+|---|---|
+| Page charge sans erreur PHP | 200 OK |
+| Script gtag.js present | `https://www.googletagmanager.com/gtag/js?id=G-JTVTDNBR0P` |
+| `window.gtag` function | Existe |
+| `window.dataLayer` | 8 entries |
+| User properties GA4 | `app_user_id`, `teamId:2`, `teamName:National`, `teamLevel:1`, `teamRoleName:Super admin`, `isSuperAdmin:true` |
+| Meta tag `current-team-id` | `2` |
+| Meta tag `current-team-level` | `1` |
+| `ga4-activity-tracker.js` charge | Oui (`asset()`) |
+| Erreurs console | Aucune |
+| PageViewLog en DB | 238 entries, derniere avec `team_id`, `user_role`, `is_super_admin` corrects |
+
+---
+
+## Diagramme de flux des config
+
+```
+.env (SISC)
+  GOOGLE_ANALYTICS_MEASUREMENT_ID=G-JTVTDNBR0P
+  GOOGLE_ANALYTICS_PROPERTY_ID=...
+       │
+       ▼
+config/services.php (SISC)         config/services.php (utils)
+  google_analytics.measurement_id ◄─── mergeConfigFrom (defaults)
+  google_analytics.property_id
+       │
+       ├──► GoogleTagManager::isEnabled()
+       ├──► google-analytics.blade.php (gtag config)
+       ├──► ServiceProvider::registerAnalyticsListeners()
+       └──► GoogleAnalyticsService (API server-side)
+
+config/analytics.php (utils, merged)
+  enabled, excluded_paths, page-view-log-model
+       │
+       └──► LogPageView middleware
+```
+
+---
+
+## Comment reutiliser dans un autre projet
+
+1. **Ajouter le package** (deja fait via composer local/submodule)
+2. **Configurer `.env`:**
+   ```
+   GOOGLE_ANALYTICS_MEASUREMENT_ID=G-XXXXXXXXXX
+   GOOGLE_ANALYTICS_PROPERTY_ID=123456789
+   ```
+3. **Inclure la vue GA dans le layout:**
+   ```blade
+   @include('kompo-utils::analytics.google-analytics')
+   ```
+4. **Ajouter le middleware au Kernel:**
+   ```php
+   'web' => [
+       // ...
+       \Condoedge\Utils\Http\Middleware\LogPageView::class,
+   ],
+   ```
+5. **Optionnel — surcharger le model:**
+   ```php
+   // config/analytics.php
+   'page-view-log-model' => \App\Models\MyCustomPageViewLog::class,
+   ```
+6. **Optionnel — GA4 Data API (server-side):**
+   ```bash
+   composer require google/analytics-data
+   ```
+   ```
+   GOOGLE_ANALYTICS_CREDENTIALS_PATH=storage/app/google/credentials.json
+   ```
+
+Les listeners Login/Logout sont auto-enregistres par le ServiceProvider si `measurement_id` est configure. Aucune action supplementaire requise.

--- a/resources/js/analytics/activity-tracker.js
+++ b/resources/js/analytics/activity-tracker.js
@@ -1,0 +1,1 @@
+// Stub: activity-tracker module placeholder

--- a/resources/views/analytics/body-top.blade.php
+++ b/resources/views/analytics/body-top.blade.php
@@ -1,0 +1,6 @@
+@if(config('services.google_tag_manager.enabled') && config('services.google_tag_manager.container_id'))
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ config('services.google_tag_manager.container_id') }}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+@endif

--- a/resources/views/analytics/google-analytics.blade.php
+++ b/resources/views/analytics/google-analytics.blade.php
@@ -1,0 +1,41 @@
+{{-- Google Analytics 4 (gtag.js) - Direct Integration --}}
+@if(config('services.google_analytics.measurement_id'))
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ config('services.google_analytics.measurement_id') }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ config('services.google_analytics.measurement_id') }}');
+</script>
+
+@auth
+@php
+    $userData = \Condoedge\Utils\Services\Analytics\GoogleTagManager::getUserData();
+    $userDataForGA = array_diff_key($userData, ['userIdRaw' => '', 'environment' => '', 'timestamp' => '']);
+@endphp
+<script>
+  // Set GA4 user properties
+  gtag('set', 'user_properties', {!! json_encode($userDataForGA, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) !!});
+
+  @if(session()->has('gtm_login_event'))
+  // Track login event
+  gtag('event', 'login', {!! json_encode(session()->pull('gtm_login_event'), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) !!});
+  @endif
+
+  @if(session()->has('gtm_pending_events'))
+  // Track pending business events (inscriptions, camps, etc.)
+  @foreach(session()->pull('gtm_pending_events', []) as $pendingEvent)
+  gtag('event', '{{ $pendingEvent['event'] }}', {!! json_encode($pendingEvent['data'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) !!});
+  @endforeach
+  @endif
+</script>
+@endauth
+
+@if(session()->has('gtm_logout_event'))
+<script>
+  // Track logout event (before user session is destroyed)
+  gtag('event', 'logout', {!! json_encode(session()->pull('gtm_logout_event'), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) !!});
+</script>
+@endif
+@endif

--- a/src/Helpers/auth.php
+++ b/src/Helpers/auth.php
@@ -21,6 +21,13 @@ if (!function_exists('safeCurrentTeamId')) {
     }
 }
 
+if (!function_exists('safeCurrentTeamRole')) {
+    function safeCurrentTeamRole()
+    {
+        return secureCall('currentTeamRole') ?? null;
+    }
+}
+
 if (!function_exists('safeGetAllTeamChildrenIds')) {
     function safeGetAllTeamChildrenIds()
     {

--- a/src/Http/Middleware/LogPageView.php
+++ b/src/Http/Middleware/LogPageView.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Condoedge\Utils\Http\Middleware;
+
+use Condoedge\Utils\Services\Analytics\GoogleTagManager;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+class LogPageView
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // Process the request first
+        $response = $next($request);
+
+        // Log page view asynchronously after response (doesn't block user)
+        if ($this->shouldLogPageView($request)) {
+            $this->logPageView($request);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Determine if the page view should be logged.
+     */
+    protected function shouldLogPageView(Request $request): bool
+    {
+        // Skip if analytics is disabled
+        if (!config('analytics.enabled', true)) {
+            return false;
+        }
+
+        // Skip excluded paths
+        $excludedPaths = config('analytics.excluded_paths', []);
+        foreach ($excludedPaths as $pattern) {
+            if ($request->is($pattern)) {
+                return false;
+            }
+        }
+
+        // Skip excluded routes
+        $excludedRoutes = config('analytics.excluded_routes', []);
+        if ($request->route() && in_array($request->route()->getName(), $excludedRoutes)) {
+            return false;
+        }
+
+        // Skip API requests (unless explicitly enabled)
+        if ($request->is('api/*') && !config('analytics.log_api_requests', false)) {
+            return false;
+        }
+
+        // Only log successful responses (2xx and 3xx)
+        // Skip 4xx and 5xx errors
+        if ($request->route() && !$request->route()->matches($request)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Log the page view to the database.
+     */
+    protected function logPageView(Request $request): void
+    {
+        try {
+            $user = auth()->user();
+            $team = safeCurrentTeam();
+            $teamRole = safeCurrentTeamRole();
+
+            // Prepare log data
+            $logData = [
+                // User identification
+                'user_id' => $user?->id,
+                'user_id_hashed' => $user ? GoogleTagManager::hashUserId($user->id) : null,
+
+                // Team context
+                'team_id' => $team?->id,
+                'team_level' => $team?->team_level?->value ?? ($team?->level ?? null),
+                'user_role' => $teamRole?->roleRelation?->name ?? ($teamRole?->role?->name ?? null),
+                'user_type' => $this->getUserType($user),
+
+                // Page information
+                'page_url' => $request->fullUrl(),
+                'page_title' => $this->extractPageTitle($request),
+                'http_method' => $request->method(),
+                'query_params' => $request->query() ?: null,
+
+                // Request metadata
+                'referer_url' => $request->header('referer'),
+                'user_agent' => $request->userAgent(),
+                'ip_address' => $request->ip(),
+                'session_id' => session()->getId(),
+
+                // User flags
+                'is_authenticated' => auth()->check(),
+                'is_super_admin' => safeIsSuperAdmin(),
+
+                // Environment
+                'environment' => config('app.env', 'production'),
+
+                // Timestamp
+                'viewed_at' => now(),
+            ];
+
+            // Resolve model class dynamically
+            $modelClass = config('analytics.page-view-log-model',
+                \Condoedge\Utils\Models\Analytics\PageViewLog::class);
+            $modelClass::create($logData);
+
+        } catch (\Exception $e) {
+            // Silently fail - don't break the application for analytics
+            Log::warning('Failed to log page view', [
+                'url' => $request->fullUrl(),
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Extract page title from request (route name or path).
+     */
+    protected function extractPageTitle(Request $request): ?string
+    {
+        // Try to get route name first
+        if ($request->route() && $request->route()->getName()) {
+            return $request->route()->getName();
+        }
+
+        // Fallback to path
+        return $request->path();
+    }
+
+    /**
+     * Determine user type based on user model.
+     */
+    protected function getUserType($user): ?string
+    {
+        if (!$user) {
+            return null;
+        }
+
+        // Check if user has specific type methods
+        if (method_exists($user, 'isScout') && $user->isScout()) {
+            return 'SCOUT';
+        }
+
+        if (method_exists($user, 'isLeader') && $user->isLeader()) {
+            return 'LEADER';
+        }
+
+        if (method_exists($user, 'isVolunteer') && $user->isVolunteer()) {
+            return 'VOLUNTEER';
+        }
+
+        if (method_exists($user, 'isParent') && $user->isParent()) {
+            return 'PARENT';
+        }
+
+        // Default to generic user type
+        return 'USER';
+    }
+}

--- a/src/Listeners/TrackUserLogin.php
+++ b/src/Listeners/TrackUserLogin.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Condoedge\Utils\Listeners;
+
+use Condoedge\Utils\Services\Analytics\GoogleTagManager;
+use Illuminate\Auth\Events\Login;
+use Illuminate\Support\Facades\Log;
+
+class TrackUserLogin
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(Login $event): void
+    {
+        if (!GoogleTagManager::isEnabled()) {
+            return;
+        }
+
+        try {
+            $user = $event->user;
+
+            // Store login time for session duration calculation on logout
+            session()->put('login_time', now());
+
+            $eventData = [
+                'app_user_id' => GoogleTagManager::hashUserId($user->id),
+                'userEmail' => $user->email,
+                'userName' => $user->name,
+            ];
+
+            // Add role if available
+            if (method_exists($user, 'getRoleNames')) {
+                $eventData['userRole'] = $user->getRoleNames()->first() ?? 'user';
+            }
+
+            // Add team context if available
+            $team = safeCurrentTeam();
+            if ($team) {
+                $eventData['teamId'] = $team->id;
+                $eventData['teamLevel'] = $team->team_level->value ?? ($team->level ?? 'unknown');
+            }
+
+            // Add login method (web, api, remember)
+            $eventData['loginMethod'] = $event->guard ?? 'web';
+            $eventData['rememberMe'] = request()->filled('remember');
+
+            // Add metadata
+            $eventData['timestamp'] = now()->toIso8601String();
+            $eventData['ipAddress'] = request()->ip();
+            $eventData['userAgent'] = request()->userAgent();
+
+            // Store in session to be pushed on next page load
+            session()->put('gtm_login_event', $eventData);
+
+            Log::info('GA4: User login tracked', ['user_id' => $user->id]);
+        } catch (\Exception $e) {
+            Log::error('GA4: Failed to track login', [
+                'error' => $e->getMessage(),
+                'user_id' => $event->user->id ?? null,
+            ]);
+        }
+    }
+}

--- a/src/Listeners/TrackUserLogout.php
+++ b/src/Listeners/TrackUserLogout.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Condoedge\Utils\Listeners;
+
+use Condoedge\Utils\Services\Analytics\GoogleTagManager;
+use Illuminate\Auth\Events\Logout;
+use Illuminate\Support\Facades\Log;
+
+class TrackUserLogout
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(Logout $event): void
+    {
+        if (!GoogleTagManager::isEnabled()) {
+            return;
+        }
+
+        try {
+            $user = $event->user;
+
+            if (!$user) {
+                return;
+            }
+
+            $eventData = [
+                'app_user_id' => GoogleTagManager::hashUserId($user->id),
+                'sessionDuration' => session()->get('login_time')
+                    ? now()->diffInMinutes(session()->get('login_time'))
+                    : null,
+                'timestamp' => now()->toIso8601String(),
+            ];
+
+            // Store in session (will be pushed before session is destroyed)
+            session()->put('gtm_logout_event', $eventData);
+
+            Log::info('GA4: User logout tracked', ['user_id' => $user->id]);
+        } catch (\Exception $e) {
+            Log::error('GA4: Failed to track logout', [
+                'error' => $e->getMessage(),
+                'user_id' => $event->user->id ?? null,
+            ]);
+        }
+    }
+}

--- a/src/Models/Analytics/PageViewLog.php
+++ b/src/Models/Analytics/PageViewLog.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace Condoedge\Utils\Models\Analytics;
+
+use Condoedge\Utils\Facades\TeamModel;
+use Condoedge\Utils\Models\Traits\BelongsToUserTrait;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Builder;
+
+class PageViewLog extends Model
+{
+    use BelongsToUserTrait;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'page_view_logs';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'user_id_hashed',
+        'team_id',
+        'team_level',
+        'user_role',
+        'user_type',
+        'page_url',
+        'page_title',
+        'http_method',
+        'query_params',
+        'referer_url',
+        'user_agent',
+        'ip_address',
+        'session_id',
+        'is_authenticated',
+        'is_super_admin',
+        'environment',
+        'viewed_at',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'query_params' => 'array',
+        'is_authenticated' => 'boolean',
+        'is_super_admin' => 'boolean',
+        'viewed_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<string>
+     */
+    protected $hidden = [
+        'ip_address',
+        'user_agent',
+        'session_id',
+    ];
+
+    /*
+    |--------------------------------------------------------------------------
+    | Relationships
+    |--------------------------------------------------------------------------
+    */
+
+    /**
+     * Get the team context for this page view.
+     */
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(TeamModel::getClass());
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Query Scopes
+    |--------------------------------------------------------------------------
+    */
+
+    /**
+     * Scope query to a specific team.
+     */
+    public function scopeForTeam(Builder $query, $team): Builder
+    {
+        $teamId = is_object($team) ? $team->id : $team;
+
+        return $query->where('team_id', $teamId);
+    }
+
+    /**
+     * Scope query to a specific user role.
+     */
+    public function scopeByRole(Builder $query, string $role): Builder
+    {
+        return $query->where('user_role', $role);
+    }
+
+    /**
+     * Scope query to a specific team level.
+     */
+    public function scopeByLevel(Builder $query, string $level): Builder
+    {
+        return $query->where('team_level', $level);
+    }
+
+    /**
+     * Scope query to a specific user type.
+     */
+    public function scopeByUserType(Builder $query, string $userType): Builder
+    {
+        return $query->where('user_type', $userType);
+    }
+
+    /**
+     * Scope query to authenticated users only.
+     */
+    public function scopeAuthenticated(Builder $query): Builder
+    {
+        return $query->where('is_authenticated', true);
+    }
+
+    /**
+     * Scope query to guest (unauthenticated) users only.
+     */
+    public function scopeGuests(Builder $query): Builder
+    {
+        return $query->where('is_authenticated', false);
+    }
+
+    /**
+     * Scope query to super admins only.
+     */
+    public function scopeSuperAdmins(Builder $query): Builder
+    {
+        return $query->where('is_super_admin', true);
+    }
+
+    /**
+     * Scope query to a date range.
+     */
+    public function scopeDateRange(Builder $query, string $startDate, string $endDate): Builder
+    {
+        return $query->whereBetween('viewed_at', [$startDate, $endDate]);
+    }
+
+    /**
+     * Scope query to today's views.
+     */
+    public function scopeToday(Builder $query): Builder
+    {
+        return $query->whereDate('viewed_at', today());
+    }
+
+    /**
+     * Scope query to this week's views.
+     */
+    public function scopeThisWeek(Builder $query): Builder
+    {
+        return $query->whereBetween('viewed_at', [
+            now()->startOfWeek(),
+            now()->endOfWeek(),
+        ]);
+    }
+
+    /**
+     * Scope query to this month's views.
+     */
+    public function scopeThisMonth(Builder $query): Builder
+    {
+        return $query->whereMonth('viewed_at', now()->month)
+            ->whereYear('viewed_at', now()->year);
+    }
+
+    /**
+     * Scope query to specific page URL.
+     */
+    public function scopeForPage(Builder $query, string $pageUrl): Builder
+    {
+        return $query->where('page_url', $pageUrl);
+    }
+
+    /**
+     * Scope query to specific HTTP method.
+     */
+    public function scopeByMethod(Builder $query, string $method): Builder
+    {
+        return $query->where('http_method', strtoupper($method));
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Accessors & Mutators
+    |--------------------------------------------------------------------------
+    */
+
+    /**
+     * Get the browser name from user agent.
+     */
+    public function getBrowserAttribute(): ?string
+    {
+        if (!$this->user_agent) {
+            return null;
+        }
+
+        if (str_contains($this->user_agent, 'Chrome')) {
+            return 'Chrome';
+        } elseif (str_contains($this->user_agent, 'Firefox')) {
+            return 'Firefox';
+        } elseif (str_contains($this->user_agent, 'Safari')) {
+            return 'Safari';
+        } elseif (str_contains($this->user_agent, 'Edge')) {
+            return 'Edge';
+        }
+
+        return 'Other';
+    }
+
+    /**
+     * Get the device type from user agent.
+     */
+    public function getDeviceTypeAttribute(): string
+    {
+        if (!$this->user_agent) {
+            return 'Unknown';
+        }
+
+        if (str_contains($this->user_agent, 'Mobile')) {
+            return 'Mobile';
+        } elseif (str_contains($this->user_agent, 'Tablet')) {
+            return 'Tablet';
+        }
+
+        return 'Desktop';
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Helper Methods
+    |--------------------------------------------------------------------------
+    */
+
+    /**
+     * Check if this page view is from a super admin.
+     */
+    public function isSuperAdmin(): bool
+    {
+        return $this->is_super_admin === true;
+    }
+
+    /**
+     * Check if this page view is from an authenticated user.
+     */
+    public function isAuthenticated(): bool
+    {
+        return $this->is_authenticated === true;
+    }
+
+    /**
+     * Get a human-readable time ago string.
+     */
+    public function getTimeAgoAttribute(): string
+    {
+        return $this->viewed_at?->diffForHumans() ?? 'Unknown';
+    }
+}

--- a/src/Services/Analytics/GoogleAnalyticsService.php
+++ b/src/Services/Analytics/GoogleAnalyticsService.php
@@ -1,0 +1,295 @@
+<?php
+
+namespace Condoedge\Utils\Services\Analytics;
+
+use Google\Analytics\Data\V1beta\Client\BetaAnalyticsDataClient;
+use Google\Analytics\Data\V1beta\DateRange;
+use Google\Analytics\Data\V1beta\Dimension;
+use Google\Analytics\Data\V1beta\Metric;
+use Google\Analytics\Data\V1beta\OrderBy;
+use Google\Analytics\Data\V1beta\OrderBy\MetricOrderBy;
+use Google\Analytics\Data\V1beta\RunRealtimeReportRequest;
+use Google\Analytics\Data\V1beta\RunReportRequest;
+use Illuminate\Support\Facades\Cache;
+use Exception;
+
+class GoogleAnalyticsService
+{
+    protected $client;
+    protected $propertyId;
+
+    public function __construct()
+    {
+        $credentialsPath = config('services.google_analytics.credentials_path');
+        $this->propertyId = config('services.google_analytics.property_id');
+
+        // Convert relative path to absolute path
+        if (!str_starts_with($credentialsPath, '/') && !preg_match('/^[A-Z]:/i', $credentialsPath)) {
+            $credentialsPath = base_path($credentialsPath);
+        }
+
+        if (!file_exists($credentialsPath)) {
+            throw new Exception("Google Analytics credentials file not found at: {$credentialsPath}");
+        }
+
+        if (!$this->propertyId) {
+            throw new Exception("Google Analytics Property ID not configured");
+        }
+
+        putenv('GOOGLE_APPLICATION_CREDENTIALS=' . $credentialsPath);
+
+        $this->client = new BetaAnalyticsDataClient();
+    }
+
+    /**
+     * Get realtime active users
+     */
+    public function getRealtimeUsers()
+    {
+        try {
+            $request = new RunRealtimeReportRequest([
+                'property' => 'properties/' . $this->propertyId,
+                'metrics' => [
+                    new Metric(['name' => 'activeUsers']),
+                ],
+            ]);
+
+            $response = $this->client->runRealtimeReport($request);
+
+            if ($response->getRows()->count() > 0) {
+                return (int) $response->getRows()[0]->getMetricValues()[0]->getValue();
+            }
+
+            return 0;
+        } catch (Exception $e) {
+            \Log::error('Google Analytics Realtime Error: ' . $e->getMessage());
+            return 0;
+        }
+    }
+
+    /**
+     * Get analytics data for a specific date range
+     */
+    public function getAnalyticsData($startDate = '30daysAgo', $endDate = 'today')
+    {
+        try {
+            \Log::info("getAnalyticsData called with dates: {$startDate} to {$endDate}");
+
+            $request = new RunReportRequest([
+                'property' => 'properties/' . $this->propertyId,
+                'date_ranges' => [
+                    new DateRange([
+                        'start_date' => $startDate,
+                        'end_date' => $endDate,
+                    ]),
+                ],
+                'metrics' => [
+                    new Metric(['name' => 'activeUsers']),
+                    new Metric(['name' => 'screenPageViews']),
+                    new Metric(['name' => 'sessions']),
+                    new Metric(['name' => 'bounceRate']),
+                    new Metric(['name' => 'averageSessionDuration']),
+                ],
+            ]);
+
+            $response = $this->client->runReport($request);
+
+            $rowCount = $response->getRows()->count();
+            \Log::info("API Response received. Row count: {$rowCount}");
+
+            $data = [];
+            if ($rowCount > 0) {
+                $row = $response->getRows()[0];
+                $metricValues = $row->getMetricValues();
+
+                $data = [
+                    'activeUsers' => (int) $metricValues[0]->getValue(),
+                    'pageViews' => (int) $metricValues[1]->getValue(),
+                    'sessions' => (int) $metricValues[2]->getValue(),
+                    'bounceRate' => round((float) $metricValues[3]->getValue() * 100, 2),
+                    'avgSessionDuration' => round((float) $metricValues[4]->getValue(), 2),
+                ];
+
+                \Log::info('Analytics data parsed successfully:', $data);
+            } else {
+                \Log::warning('No rows returned from Google Analytics API - returning default values');
+                $data = [
+                    'activeUsers' => 0,
+                    'pageViews' => 0,
+                    'sessions' => 0,
+                    'bounceRate' => 0,
+                    'avgSessionDuration' => 0,
+                ];
+            }
+
+            return $data;
+        } catch (Exception $e) {
+            \Log::error('Google Analytics Data Error: ' . $e->getMessage());
+            \Log::error('Stack trace: ' . $e->getTraceAsString());
+
+            return [
+                'activeUsers' => 0,
+                'pageViews' => 0,
+                'sessions' => 0,
+                'bounceRate' => 0,
+                'avgSessionDuration' => 0,
+            ];
+        }
+    }
+
+    /**
+     * Get top pages
+     */
+    public function getTopPages($limit = 10)
+    {
+        try {
+            $request = new RunReportRequest([
+                'property' => 'properties/' . $this->propertyId,
+                'date_ranges' => [
+                    new DateRange([
+                        'start_date' => '30daysAgo',
+                        'end_date' => 'today',
+                    ]),
+                ],
+                'dimensions' => [
+                    new Dimension(['name' => 'pagePath']),
+                    new Dimension(['name' => 'pageTitle']),
+                ],
+                'metrics' => [
+                    new Metric(['name' => 'screenPageViews']),
+                ],
+                'limit' => $limit,
+            ]);
+
+            // Add order by
+            $orderBy = new \Google\Analytics\Data\V1beta\OrderBy();
+            $metricOrderBy = new \Google\Analytics\Data\V1beta\OrderBy\MetricOrderBy();
+            $metricOrderBy->setMetricName('screenPageViews');
+            $orderBy->setMetric($metricOrderBy);
+            $orderBy->setDesc(true);
+            $request->setOrderBys([$orderBy]);
+
+            $response = $this->client->runReport($request);
+
+            $pages = [];
+            foreach ($response->getRows() as $row) {
+                $pages[] = [
+                    'path' => $row->getDimensionValues()[0]->getValue(),
+                    'title' => $row->getDimensionValues()[1]->getValue(),
+                    'views' => (int) $row->getMetricValues()[0]->getValue(),
+                ];
+            }
+
+            return $pages;
+        } catch (Exception $e) {
+            \Log::error('Google Analytics Top Pages Error: ' . $e->getMessage());
+            return [];
+        }
+    }
+
+    /**
+     * Get traffic sources
+     */
+    public function getTrafficSources()
+    {
+        try {
+            $request = new RunReportRequest([
+                'property' => 'properties/' . $this->propertyId,
+                'date_ranges' => [
+                    new DateRange([
+                        'start_date' => '30daysAgo',
+                        'end_date' => 'today',
+                    ]),
+                ],
+                'dimensions' => [
+                    new Dimension(['name' => 'sessionSource']),
+                    new Dimension(['name' => 'sessionMedium']),
+                ],
+                'metrics' => [
+                    new Metric(['name' => 'sessions']),
+                ],
+            ]);
+
+            // Add order by
+            $orderBy = new \Google\Analytics\Data\V1beta\OrderBy();
+            $metricOrderBy = new \Google\Analytics\Data\V1beta\OrderBy\MetricOrderBy();
+            $metricOrderBy->setMetricName('sessions');
+            $orderBy->setMetric($metricOrderBy);
+            $orderBy->setDesc(true);
+            $request->setOrderBys([$orderBy]);
+
+            $response = $this->client->runReport($request);
+
+            $sources = [];
+            foreach ($response->getRows() as $row) {
+                $sources[] = [
+                    'source' => $row->getDimensionValues()[0]->getValue(),
+                    'medium' => $row->getDimensionValues()[1]->getValue(),
+                    'sessions' => (int) $row->getMetricValues()[0]->getValue(),
+                ];
+            }
+
+            return $sources;
+        } catch (Exception $e) {
+            \Log::error('Google Analytics Traffic Sources Error: ' . $e->getMessage());
+            return [];
+        }
+    }
+
+    /**
+     * Get device breakdown
+     */
+    public function getDeviceBreakdown()
+    {
+        try {
+            $request = new RunReportRequest([
+                'property' => 'properties/' . $this->propertyId,
+                'date_ranges' => [
+                    new DateRange([
+                        'start_date' => '30daysAgo',
+                        'end_date' => 'today',
+                    ]),
+                ],
+                'dimensions' => [
+                    new Dimension(['name' => 'deviceCategory']),
+                ],
+                'metrics' => [
+                    new Metric(['name' => 'activeUsers']),
+                ],
+            ]);
+
+            $response = $this->client->runReport($request);
+
+            $devices = [];
+            foreach ($response->getRows() as $row) {
+                $devices[] = [
+                    'device' => $row->getDimensionValues()[0]->getValue(),
+                    'users' => (int) $row->getMetricValues()[0]->getValue(),
+                ];
+            }
+
+            return $devices;
+        } catch (Exception $e) {
+            \Log::error('Google Analytics Device Breakdown Error: ' . $e->getMessage());
+            return [];
+        }
+    }
+
+    /**
+     * Get cached dashboard data (refresh every 5 minutes)
+     */
+    public function getDashboardData()
+    {
+        return Cache::remember('google_analytics_dashboard', 300, function () {
+            return [
+                'realtime' => $this->getRealtimeUsers(),
+                'overview' => $this->getAnalyticsData('30daysAgo', 'today'),
+                'today' => $this->getAnalyticsData('today', 'today'),
+                'yesterday' => $this->getAnalyticsData('yesterday', 'yesterday'),
+                'topPages' => $this->getTopPages(10),
+                'trafficSources' => $this->getTrafficSources(),
+                'devices' => $this->getDeviceBreakdown(),
+            ];
+        });
+    }
+}

--- a/src/Services/Analytics/GoogleTagManager.php
+++ b/src/Services/Analytics/GoogleTagManager.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Condoedge\Utils\Services\Analytics;
+
+class GoogleTagManager
+{
+    /**
+     * Check if analytics tracking is enabled (GA4 measurement ID configured)
+     */
+    public static function isEnabled(): bool
+    {
+        return !empty(config('services.google_analytics.measurement_id'));
+    }
+
+    /**
+     * Get the GA4 measurement ID
+     */
+    public static function getMeasurementId(): ?string
+    {
+        return config('services.google_analytics.measurement_id');
+    }
+
+    /**
+     * Get current user data for GA4 user properties
+     * Includes user identity, team context, and metadata
+     */
+    public static function getUserData(): array
+    {
+        if (!auth()->check()) {
+            return [];
+        }
+
+        $user = auth()->user();
+
+        // Basic user identity (hashed for privacy)
+        $userData = [
+            'app_user_id' => self::hashUserId($user->id),
+            'userIdRaw' => $user->id, // Keep raw for internal tracking (will filter in blade)
+            'userEmail' => $user->email,
+            'userName' => $user->name,
+        ];
+
+        // User role
+        if (method_exists($user, 'getRoleNames')) {
+            $userData['userRole'] = $user->getRoleNames()->first() ?? 'user';
+        }
+
+        // Team context (multi-tenancy)
+        $team = safeCurrentTeam();
+        if ($team) {
+            $userData['teamId'] = $team->id;
+            $userData['teamLevel'] = $team->team_level->value ?? ($team->level ?? 'unknown');
+        }
+
+        $teamRole = safeCurrentTeamRole();
+        if ($teamRole) {
+            $userData['teamRoleId'] = $teamRole->id;
+            $userData['teamRoleName'] = $teamRole->roleRelation->name ?? ($teamRole->role->name ?? 'unknown');
+        }
+
+        // User type flags
+        $userData['isParent'] = method_exists($user, 'isParent') ? $user->isParent() : false;
+        $userData['isSuperAdmin'] = safeIsSuperAdmin();
+
+        // Metadata
+        $userData['environment'] = config('app.env');
+        $userData['timestamp'] = now()->toIso8601String();
+
+        return $userData;
+    }
+
+    /**
+     * Hash user ID for privacy (GDPR compliance)
+     * Uses SHA-256 with app key as salt
+     */
+    public static function hashUserId($userId): string
+    {
+        return hash('sha256', config('app.key') . $userId);
+    }
+}


### PR DESCRIPTION
## Summary
- Add reusable GA4 tracking infrastructure to condoedge/utils
- Provides services, middleware, listeners, model, migration and Blade views that any project can use
- Uses safe helpers and facades (TeamModel, UserModel) — zero app-specific dependencies

## New files
- `Services/Analytics/GoogleTagManager.php` — isEnabled, getUserData, hashUserId (uses safeCurrentTeam, safeCurrentTeamRole, safeIsSuperAdmin)
- `Services/Analytics/GoogleAnalyticsService.php` — GA4 Data API wrapper (server-side)
- `Http/Middleware/LogPageView.php` — server-side page view logging with dynamic model resolution via `config('analytics.page-view-log-model')`
- `Listeners/TrackUserLogin.php` / `TrackUserLogout.php` — auto-registered by ServiceProvider when measurement_id is configured
- `Models/Analytics/PageViewLog.php` — uses BelongsToUserTrait + TeamModel facade, generic scopeForTeam
- `views/analytics/google-analytics.blade.php` — gtag.js script + user properties + session events
- `views/analytics/body-top.blade.php` — GTM noscript fallback
- `config/analytics.php` — page view logging config with page-view-log-model key
- `config/services.php` — added google_analytics + google_tag_manager blocks
- Migration with conditional FK on teams table (`Schema::hasTable`)

## Modified files
- `src/Helpers/auth.php` — added `safeCurrentTeamRole()` helper
- `src/CondoedgeUtilsServiceProvider.php` — registers analytics config, GoogleAnalyticsService singleton, Login/Logout listeners
- `composer.json` — added `suggest` for google/analytics-data

## How to use in a project
1. Set `GOOGLE_ANALYTICS_MEASUREMENT_ID` in `.env`
2. Include `@include('kompo-utils::analytics.google-analytics')` in layout
3. Add `\Condoedge\Utils\Http\Middleware\LogPageView::class` to Kernel web middleware
4. Listeners are auto-registered — no extra config needed

## Test plan
- [x] Tested on SISC local — dashboard loads, GA4 gtag.js present, user properties sent correctly
- [x] PageViewLog entries created with team_id, user_role, is_super_admin
- [x] Zero console errors, zero PHP errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)