### PR TITLE
feat: GSAP tutorial cursor support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
     "semantic-release": "^24.2.5"
   },
   "dependencies": {
-    "libphonenumber-js": "^1.11.7",
-    "intro.js": "^7.2.0",
-    "vue-kompo": "^3.0.49",
+    "@ckeditor/ckeditor5-vue2": "^3.0.1",
     "ckeditor5": "^44.3.0",
-    "@ckeditor/ckeditor5-vue2": "^3.0.1"
+    "gsap": "^3.14.2",
+    "intro.js": "^7.2.0",
+    "libphonenumber-js": "^1.11.7",
+    "vue-kompo": "^3.0.49"
   }
 }

--- a/resources/js/utils.js
+++ b/resources/js/utils.js
@@ -75,12 +75,21 @@ function removeLoadingScreen()
 import introJs from 'intro.js';
 window.introJs = introJs;
 
+import { gsap } from 'gsap';
+import { MotionPathPlugin } from 'gsap/MotionPathPlugin';
+import { MotionPathHelper } from 'gsap/MotionPathHelper';
+gsap.registerPlugin(MotionPathPlugin, MotionPathHelper);
+window.gsap = gsap;
+window.MotionPathPlugin = MotionPathPlugin;
+window.MotionPathHelper = MotionPathHelper;
+
 window.utils = {
 	getYesNoValue: getYesNoValue,
 	getToggle: getToggle,
 	getToggleValue: getToggleValue,
 	toggleYesNo: toggleYesNo,
 	introJs: introJs,
+	gsap: gsap,
 	setLoadingScreen: setLoadingScreen,
 	removeLoadingScreen: removeLoadingScreen
 };

--- a/src/Kompo/Plugins/HasIntroAnimation.php
+++ b/src/Kompo/Plugins/HasIntroAnimation.php
@@ -30,35 +30,43 @@ class HasIntroAnimation extends ComponentPlugin
             return;
         }
 
-        if (!in_array(HasUserSettings::class, class_uses(UserModel::getClass()))) {
-            \Log::error('The component must implement HasUserSettings trait to use HasIntroAnimation plugin. If you are not using it you can disable the plugin using `excludePlugins` method');
-            return;
-        }
+        $alwaysShow = $this->componentHasMethod('alwaysShowIntro') ? $this->callComponentMethod('alwaysShowIntro') : false;
 
-        if (!$skipIntro && !componentIntroViewed($this->component)) {
-            auth()->user()->saveSetting(componentIntroViewedKey($this->component), true);
-
-            $translatedContent = $this->translateContent(file_get_contents($filePath));
-            $replacedContent = $this->replaceContentWithVariables($translatedContent);
-        	$introJs = $this->managePhpInjections($replacedContent);
-
-            try {
-                $filesIncluded = array_diff(
-                    scandir(resource_path('views/scripts/animation_dependencies')), 
-                    ['.', '..']
-                );
-
-                foreach ($filesIncluded as $file) {
-                    $introJs = file_get_contents(resource_path("views/scripts/animation_dependencies/{$file}")) . "\n" . $introJs;
-                }
-            } catch (\Exception $e) {
-                // No dependencies found, continue
+        if (!$alwaysShow) {
+            if (!in_array(HasUserSettings::class, class_uses(UserModel::getClass()))) {
+                \Log::error('The component must implement HasUserSettings trait to use HasIntroAnimation plugin. If you are not using it you can disable the plugin using `excludePlugins` method');
+                return;
             }
 
-            return $introJs;
+            if ($skipIntro || componentIntroViewed($this->component)) {
+                return '';
+            }
+
+            auth()->user()->saveSetting(componentIntroViewedKey($this->component), true);
         }
 
-        return '';
+        $translatedContent = $this->translateContent(file_get_contents($filePath));
+        $replacedContent = $this->replaceContentWithVariables($translatedContent);
+        $introJs = $this->managePhpInjections($replacedContent);
+
+        try {
+            $filesIncluded = array_diff(
+                scandir(resource_path('views/scripts/animation_dependencies')),
+                ['.', '..']
+            );
+
+            foreach ($filesIncluded as $file) {
+                $introJs = file_get_contents(resource_path("views/scripts/animation_dependencies/{$file}")) . "\n" . $introJs;
+            }
+        } catch (\Exception $e) {
+            // No dependencies found, continue
+        }
+
+        if (config('app.debug')) {
+            $introJs = "window.__TUTORIAL_DEV = true;\n" . $introJs;
+        }
+
+        return $introJs;
     }
 
     protected function getPrefixFile()


### PR DESCRIPTION
## Summary
- Import GSAP + MotionPathPlugin + MotionPathHelper in `utils.js` and expose globally
- Add `alwaysShowIntro()` support in `HasIntroAnimation.php` for guest/always-visible tutorials
- Inject `window.__TUTORIAL_DEV = true` flag in debug mode for the tutorial step builder

## Test plan
- [ ] Verify GSAP is available via `window.gsap` after webpack build
- [ ] Test `alwaysShowIntro()` on a guest page (no auth user)
- [ ] Confirm `window.__TUTORIAL_DEV` is set only when `APP_DEBUG=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)