### PR TITLE
Add ApexChart Kompo element and _ApexChart helper

### DIFF
--- a/src/Helpers/elements/components.php
+++ b/src/Helpers/elements/components.php
@@ -45,6 +45,21 @@ function _SignaturePad()
     return \Condoedge\Utils\Kompo\Elements\SignaturePad::form(...func_get_args());
 }
 
+/**
+ * Render an ApexCharts chart inside a Kompo element.
+ *
+ * Requires the VlApexChart Vue component from condoedge/js-kompo-utils to be
+ * registered in the host app (auto-registered via getAllDefaultComponents()).
+ *
+ * @param  array $chartOptions  Raw ApexCharts options (chart, series, xaxis, etc.)
+ * @return \Condoedge\Utils\Kompo\Elements\ApexChart
+ */
+function _ApexChart($chartOptions = [])
+{
+    return \Condoedge\Utils\Kompo\Elements\ApexChart::form()
+        ->config(['chartOptions' => $chartOptions]);
+}
+
 function _Text()
 {
     return \Condoedge\Utils\Kompo\Elements\Text::form(...func_get_args());

--- a/src/Kompo/Elements/ApexChart.php
+++ b/src/Kompo/Elements/ApexChart.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Condoedge\Utils\Kompo\Elements;
+
+use Kompo\Elements\Block;
+
+class ApexChart extends Block
+{
+    public $vueComponent = 'ApexChart';
+}


### PR DESCRIPTION
## Summary

Adds a thin PHP bridge to the `VlApexChart` Vue component already shipped by `condoedge/js-kompo-utils`, so any host app that pulls in `condoedge/utils` can render an ApexCharts instance through a single helper call:

```php
_ApexChart([
    'chart'  => ['type' => 'line', 'height' => 320],
    'series' => [...],
    'xaxis'  => ['categories' => [...]],
])
```

## Why

Every project that wanted an ApexCharts chart has been re-declaring the same two pieces locally:

- A Kompo `Block` subclass with `public $vueComponent = 'ApexChart'`
- A `_ApexChart($options)` helper that forwards the options into the Kompo config

It is currently duplicated at least in **Coolecto's admin dashboard** (`app/Kompo/Components/ApexChart.php` + `app/Kompo/Helpers/components.php`) and in **SISC** (introduced on the in-flight *My team page* branch). Both copies are byte-identical to what this PR lands.

Moving both pieces here keeps them next to the other reusable Kompo elements already exposed by `condoedge/utils` (`ResponsiveTabs`, `Collapsible`, `SwipeableTabs`, `ValidatedInput`, `SignaturePad`, etc.) and lets those two apps drop their local copies in a follow-up PR.

## Contents

- **`src/Kompo/Elements/ApexChart.php`** — a `Block` subclass with `vueComponent = 'ApexChart'`, so Kompo resolves it to the `VlApexChart` Vue component at render time.
- **`src/Helpers/elements/components.php`** — new `_ApexChart($chartOptions = [])` helper placed right next to the existing `_Collapsible` / `_ResponsiveTabs` / `_SignaturePad` helpers. Pushes the options into the Kompo config under the `chartOptions` key, which the Vue component reads on mount.

No autoload change needed — `components.php` is already picked up by `src/Helpers/loader.php` via its `glob()`.

## Runtime dependency

No new runtime dependency. `apexcharts` itself lives in the frontend package (`condoedge/js-kompo-utils`) where `VlApexChart` is auto-registered via `getAllDefaultComponents()`. Apps that already use `condoedge/utils` together with `condoedge/js-kompo-utils` get this working out of the box. Apps that opt out of `VlApexChart` via `config.excludeComponent('VlApexChart')` will simply render nothing (same behaviour as today).

## Follow-ups in consumer apps

Once this is merged and the consumer apps bump their `condoedge/utils` version:

- **SISC** (`feature/my-team-page`, PR #1221): drop `app/Kompo/Components/ApexChart.php` and the local `_ApexChart` function in `app/Kompo/Helpers/elements.php`; the existing call sites (`MyTeamInformationTab`) keep working unchanged because the helper name is the same.
- **Coolecto**: same cleanup in its admin dashboard files.

## Test plan

- [ ] `composer dump-autoload` in a consumer app picks up the new helper
- [ ] Calling `_ApexChart([...])` in a Kompo render returns a block whose `vueComponent` resolves to `VlApexChart`
- [ ] Rendering a simple line chart with a few series displays as expected in a page that has `condoedge/js-kompo-utils` loaded
- [ ] Apps already declaring their own local `_ApexChart` do not collide (both paths are guarded by `function_exists` in their own files; this PR's version is unconditional but can be wrapped in `if (!function_exists('_ApexChart'))` if collisions surface during rollout — happy to adjust in review)