### PR TITLE
Fix _ApexChart helper: forward options via config, not as element label

### DIFF
--- a/src/Helpers/elements/components.php
+++ b/src/Helpers/elements/components.php
@@ -75,8 +75,18 @@ if (!function_exists('_PasswordInput')) {
 }
 
 if (!function_exists('_ApexChart')) {
-    function _ApexChart()
+    /**
+     * Render an ApexCharts chart inside a Kompo element.
+     *
+     * Requires the VlApexChart Vue component from condoedge/js-kompo-utils to be
+     * registered in the host app (auto-registered via getAllDefaultComponents()).
+     *
+     * @param  array $chartOptions  Raw ApexCharts options (chart, series, xaxis, etc.)
+     * @return \Condoedge\Utils\Kompo\Elements\ApexChart
+     */
+    function _ApexChart($chartOptions = [])
     {
-        return \Condoedge\Utils\Kompo\Elements\ApexChart::form(...func_get_args());
+        return \Condoedge\Utils\Kompo\Elements\ApexChart::form()
+            ->config(['chartOptions' => $chartOptions]);
     }
 }


### PR DESCRIPTION
## Summary

Fix-only PR targeting `main`. Changes **one helper function** in `src/Helpers/elements/components.php`. No change to `ApexChart.php` — the Block class shipped in v0.2.161 is already correct.

## The bug

The current `_ApexChart` helper on `main` (and therefore in the v0.2.161 release) forwards its arguments with `...func_get_args()` into `ApexChart::form(...)`:

```php
if (!function_exists('_ApexChart')) {
    function _ApexChart()
    {
        return \Condoedge\Utils\Kompo\Elements\ApexChart::form(...func_get_args());
    }
}
```

Because `BaseElement::form()` ultimately does `new static(...$arguments)`, the chart options **array** lands as the element's `$label`. `Element::initialize()` then feeds that label to `strip_tags()`, which crashes:

```
TypeError: strip_tags(): Argument #1 ($string) must be of type string, array given
  at Kompo\Core\KompoId::setForElement (vendor/kompo/kompo/src/Core/KompoId.php:13)
```

This trips on any realistic usage, including the simplest:

```php
_ApexChart([
    'chart'  => ['type' => 'line'],
    'series' => [...],
]);
```

So the helper as shipped in v0.2.161 is effectively unusable. I hit it right after consuming the release in SISC's in-flight My team page.

## The fix

`VlApexChart` (the Vue component that ships from `condoedge/js-kompo-utils`) reads its options from the Kompo config under the `chartOptions` key:

```js
let options = this.$_config('chartOptions') || {}
```

So the right channel is `->config(['chartOptions' => ...])`, not the element label. This PR changes the helper accordingly:

```php
if (!function_exists('_ApexChart')) {
    /**
     * Render an ApexCharts chart inside a Kompo element.
     *
     * Requires the VlApexChart Vue component from condoedge/js-kompo-utils to be
     * registered in the host app (auto-registered via getAllDefaultComponents()).
     */
    function _ApexChart(\$chartOptions = [])
    {
        return \Condoedge\Utils\Kompo\Elements\ApexChart::form()
            ->config(['chartOptions' => \$chartOptions]);
    }
}
```

This is the same wrapper pattern already battle-tested in Coolecto's admin dashboard and in SISC. The `function_exists` guard stays so host apps that already defined a local `_ApexChart` keep working until they drop their copy.

## Test plan

- [ ] `_ApexChart(['chart' => ['type' => 'line'], 'series' => [[ 'name' => 'x', 'data' => [1,2,3] ]]])` renders a line chart instead of throwing
- [ ] Existing call sites in consumer apps (SISC MyTeamInformationTab, Coolecto AdminDashboard) keep working once they pull a release including this fix
- [ ] No regression on the other helpers in `components.php` — only lines 84-89 are touched

## Release note candidate (for whenever v0.2.162 gets cut)

`Fix: _ApexChart helper now forwards options through the Kompo config as expected by VlApexChart, instead of passing them as the element label which caused a strip_tags() TypeError on every call.`