### PR TITLE
Allow tabs to be targeted by tab_id in addition to tab_number

### DIFF
--- a/src/Helpers/elements/lazy-components.php
+++ b/src/Helpers/elements/lazy-components.php
@@ -180,9 +180,15 @@ function _LazyTabs(...$tabs)
                     $closure = getPrivateProperty($lazyElement, 'closure') ?? null;
 
                     if ($closure) {
-                        return _SwipeableTab(
+                        $rebuilt = _SwipeableTab(
                             $closure()
                         )->label(getPrivateProperty($tab, 'label'));
+
+                        if ($tab && !empty($tab->id)) {
+                            $rebuilt->id($tab->id);
+                        }
+
+                        return $rebuilt;
                     }
                 } catch (\Exception $e) {
                     // If any error occurs during reflection, fallback to original tab (that uses by default lazy loading)

--- a/src/Kompo/Elements/ResponsiveTabs.php
+++ b/src/Kompo/Elements/ResponsiveTabs.php
@@ -110,6 +110,7 @@ class ResponsiveTabs extends Rows
 
         return _SwipeableTabs(...$this->elements)
             ->commonClass("hidden {$this->breakpoint}:block mr-8")
+            ->activeTab($this->resolveActiveTabIndex())
             ->when($this->tabsClass, fn ($el) => $el->class($this->tabsClass))
             ->when($this->tabsCommonClass, fn ($el) => $el->commonClass($this->tabsCommonClass . " hidden {$this->breakpoint}:block"))
             ->when($this->tabsSelectedClass, fn ($el) => $el->selectedClass($this->tabsSelectedClass, $this->tabsUnselectedClass))
@@ -129,11 +130,36 @@ class ResponsiveTabs extends Rows
                 'readonly' => 'readonly',
             ])
             ->options($this->tabLabels)
-            ->value(request('tab_number') ?: 0)
+            ->value($this->resolveActiveTabIndex())
             ->onChange(
                 fn ($e) => $e
                     ->run($this->jsSelect())
             );
+    }
+
+    /**
+     * Resolve the initially active tab index from the request.
+     *
+     * Priority: tab_id (semantic, matched against each tab's ->id()) →
+     * tab_number (numeric index, legacy) → 0.
+     */
+    /**
+     * Resolve the initially active tab index from the request.
+     *
+     * Priority: tab_id (semantic, matched against each tab's ->id()) →
+     * tab_number (numeric index, legacy) → 0.
+     */
+    protected function resolveActiveTabIndex(): int
+    {
+        if ($tabId = request('tab_id')) {
+            foreach ($this->elements as $index => $tab) {
+                if ($tab && !empty($tab->id) && $tab->id === $tabId) {
+                    return $index;
+                }
+            }
+        }
+
+        return (int) (request('tab_number') ?: 0);
     }
 
     protected function jsSelect()


### PR DESCRIPTION
## Summary

Two tiny, coordinated changes to `ResponsiveTabs` + `_LazyTabs` so that tabs can be targeted by a semantic slug (`tab_id`) instead of their numeric index (`tab_number`) when that index differs between the source and the destination of a navigation.

## Why

SISC's in-flight *My team page* (PR #1221) reached a point where clicking a child team in a level-dependent tab list (Groupes / Comités / …) needs to land on the semantically equivalent tab at the destination (Unités / Comités / …). The destination's numeric layout differs from the source's because some tabs are hidden based on level or permissions (e.g. Scouts is hidden at national/district). Encoding the click as `tab_id=<slug>` instead of `tab_number=<index>` is the minimal-coupling solution, but the package didn't support it yet. This PR unblocks it at the package level so any consumer can opt in with two extra characters (`->id('slug')` on their tab).

## Changes

### 1. `ResponsiveTabs::resolveActiveTabIndex()`

Adds a small helper that resolves the initially active tab from the request in this order:
1. `tab_id` — semantic slug, matched against each tab's `->id()`
2. `tab_number` — numeric index (legacy)
3. `0`

The helper is used both in `tabsDecorated()` (desktop SwipeableTabs) and in `selectTabs()` (mobile select) so both layouts behave identically.

```php
protected function resolveActiveTabIndex(): int
{
    if (\$tabId = request('tab_id')) {
        foreach (\$this->elements as \$index => \$tab) {
            if (\$tab && !empty(\$tab->id) && \$tab->id === \$tabId) {
                return \$index;
            }
        }
    }
    return (int) (request('tab_number') ?: 0);
}
```

Apps still relying on `?tab_number=X` keep working unchanged.

### 2. `_LazyTabs` preserves the source tab's id when rebuilding

`_LazyTabs` builds the currently active tab eagerly (closure invoked server-side) while leaving the others lazy. When it does that, it reconstructs a new `_SwipeableTab` wrapping the rendered content and copies the original tab's label — but it dropped the `->id()` set by the caller. Because the currently active tab is by default index `0`, the first tab always lost its id, making the new `tab_id` lookup fail for it.

```diff
-return _SwipeableTab(\$closure())->label(getPrivateProperty(\$tab, 'label'));
+\$rebuilt = _SwipeableTab(\$closure())->label(getPrivateProperty(\$tab, 'label'));
+if (\$tab && !empty(\$tab->id)) {
+    \$rebuilt->id(\$tab->id);
+}
+return \$rebuilt;
```

No behaviour change for tabs that don't set an id.

## Pairs with a Vue side fix

On the frontend, `VlSwipeableTabs` (shipped by `condoedge/js-kompo-utils`) currently lets a stale `tab_number` query string — carried over by Kompo's SPA navigation from the previous page — override the server's `->activeTab()`. A companion PR on `condoedge/js-kompo-utils` inverts that priority (server wins) and adds a watcher so the component re-syncs when the config changes on a subsequent navigation. The two PRs must land together for the full fix; either one alone is insufficient.

## Test plan

- [ ] `_LazyTab(fn () => …)->id('teams')->label('…')` retains its id after `_LazyTabs` rebuilds it
- [ ] `?tab_id=teams` in the URL activates the tab with matching id
- [ ] `?tab_number=2` still activates the 2nd tab (backward compat)
- [ ] No regression on pages that don't set `tab_id` — first tab remains the default
- [ ] Mobile `selectTabs` follows the same resolution (checked via the Select value)