### PR TITLE
Translation tooling: smarter analyzer + triage state + desktop GUI

### DIFF
--- a/database/migrations/2026_04_22_000001_add_locale_and_hit_count_to_missing_translations.php
+++ b/database/migrations/2026_04_22_000001_add_locale_and_hit_count_to_missing_translations.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('missing_translations', function (Blueprint $table) {
+            $table->string('locale', 10)->nullable()->after('translation_key');
+            $table->unsignedInteger('hit_count')->default(1)->after('package');
+            $table->timestamp('last_seen_at')->nullable()->after('hit_count');
+        });
+
+        // Replace the existing unique(translation_key) with a composite unique(translation_key, locale).
+        Schema::table('missing_translations', function (Blueprint $table) {
+            try {
+                $table->dropUnique(['translation_key']);
+            } catch (\Throwable $e) {
+                // Index name may differ; ignore if already gone.
+            }
+            $table->unique(['translation_key', 'locale'], 'missing_translations_key_locale_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('missing_translations', function (Blueprint $table) {
+            $table->dropUnique('missing_translations_key_locale_unique');
+            $table->unique('translation_key');
+            $table->dropColumn(['locale', 'hit_count', 'last_seen_at']);
+        });
+    }
+};

--- a/database/migrations/2026_04_23_000001_drop_missing_translations_table.php
+++ b/database/migrations/2026_04_23_000001_drop_missing_translations_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The missing-translation tracking moved to a JSON-backed store
+ * (storage/app/missing_translations.json) managed by
+ * Condoedge\Utils\Services\Translation\MissingTranslationsStore.
+ * Historical DB rows are not migrated — fresh JSON replaces them.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::dropIfExists('missing_translations');
+    }
+
+    public function down(): void
+    {
+        Schema::create('missing_translations', function (Blueprint $table) {
+            if (function_exists('addMetaData')) {
+                addMetaData($table);
+            } else {
+                $table->id();
+                $table->timestamps();
+            }
+            $table->string('translation_key');
+            $table->string('locale', 8)->nullable();
+            $table->unsignedInteger('hit_count')->default(0);
+            $table->timestamp('last_seen_at')->nullable();
+            $table->timestamp('ignored_at')->nullable();
+            $table->timestamp('fixed_at')->nullable();
+            $table->string('package')->nullable();
+            $table->string('file_path')->nullable();
+            $table->unique(['translation_key', 'locale']);
+        });
+    }
+};

--- a/src/Command/LinkedPackagesCommand.php
+++ b/src/Command/LinkedPackagesCommand.php
@@ -2,6 +2,7 @@
 
 namespace Condoedge\Utils\Command;
 
+use Condoedge\Utils\Services\Translation\LocaleFilesRepository;
 use Illuminate\Console\Command;
 
 class LinkedPackagesCommand extends Command
@@ -12,66 +13,82 @@ class LinkedPackagesCommand extends Command
 
     protected $description = 'Manage local package paths scanned by the translation analyzer.';
 
-    public function handle(): int
+    public function handle(LocaleFilesRepository $repo): int
     {
-        $action = $this->argument('action');
-        $path = $this->argument('path');
+        $action  = $this->argument('action');
+        $path    = $this->argument('path');
+        $current = $repo->linkedPackages();
 
-        $current = MissingTranslationAnalyzerCommand::loadLinkedPackages();
+        return match ($action) {
+            'list'   => $this->listPackages($current),
+            'add'    => $this->addPackage($repo, $current, $path),
+            'remove' => $this->removePackage($repo, $current, $path),
+            'clear'  => $this->clearPackages($repo),
+            default  => $this->invalidAction($action),
+        };
+    }
 
-        switch ($action) {
-            case 'list':
-                if (empty($current)) {
-                    $this->info('No linked packages.');
-                    return Command::SUCCESS;
-                }
-                $this->info('Linked packages:');
-                foreach ($current as $p) {
-                    $marker = is_dir($p) ? '✓' : '✗ (missing)';
-                    $this->line("  {$marker}  {$p}");
-                }
-                return Command::SUCCESS;
-
-            case 'add':
-                if (!$path) {
-                    $this->error('Provide a path: php artisan app:translator-packages add /path/to/package');
-                    return Command::INVALID;
-                }
-                $real = realpath($path);
-                if (!$real || !is_dir($real)) {
-                    $this->error("Not a directory: {$path}");
-                    return Command::INVALID;
-                }
-                $current[] = $real;
-                MissingTranslationAnalyzerCommand::saveLinkedPackages($current);
-                $this->info("Linked: {$real}");
-                return Command::SUCCESS;
-
-            case 'remove':
-                if (!$path) {
-                    $this->error('Provide a path: php artisan app:translator-packages remove /path/to/package');
-                    return Command::INVALID;
-                }
-                $target = realpath($path) ?: $path;
-                $filtered = array_values(array_filter($current, function ($p) use ($target) {
-                    return $p !== $target && realpath($p) !== $target;
-                }));
-                if (count($filtered) === count($current)) {
-                    $this->warn("Not found in linked list: {$path}");
-                    return Command::SUCCESS;
-                }
-                MissingTranslationAnalyzerCommand::saveLinkedPackages($filtered);
-                $this->info("Unlinked: {$target}");
-                return Command::SUCCESS;
-
-            case 'clear':
-                MissingTranslationAnalyzerCommand::saveLinkedPackages([]);
-                $this->info('Cleared all linked packages.');
-                return Command::SUCCESS;
-
-            default:
-                $this->error("Unknown action: {$action}. Use list | add | remove | clear.");
-                return Command::INVALID;
+    private function listPackages(array $current): int
+    {
+        if (empty($current)) {
+            $this->info('No linked packages.');
+            return Command::SUCCESS;
         }
+        $this->info('Linked packages:');
+        foreach ($current as $p) {
+            $marker = is_dir($p) ? '✓' : '✗ (missing)';
+            $this->line("  {$marker}  {$p}");
+        }
+        return Command::SUCCESS;
+    }
+
+    private function addPackage(LocaleFilesRepository $repo, array $current, ?string $path): int
+    {
+        if (!$path) {
+            $this->error('Provide a path: php artisan app:translator-packages add /path/to/package');
+            return Command::INVALID;
+        }
+        $real = realpath($path);
+        if (!$real || !is_dir($real)) {
+            $this->error("Not a directory: {$path}");
+            return Command::INVALID;
+        }
+        $current[] = $real;
+        $repo->saveLinkedPackages($current);
+        $this->info("Linked: {$real}");
+        return Command::SUCCESS;
+    }
+
+    private function removePackage(LocaleFilesRepository $repo, array $current, ?string $path): int
+    {
+        if (!$path) {
+            $this->error('Provide a path: php artisan app:translator-packages remove /path/to/package');
+            return Command::INVALID;
+        }
+        $target   = realpath($path) ?: $path;
+        $filtered = array_values(array_filter(
+            $current,
+            fn($p) => $p !== $target && realpath($p) !== $target
+        ));
+        if (count($filtered) === count($current)) {
+            $this->warn("Not found in linked list: {$path}");
+            return Command::SUCCESS;
+        }
+        $repo->saveLinkedPackages($filtered);
+        $this->info("Unlinked: {$target}");
+        return Command::SUCCESS;
+    }
+
+    private function clearPackages(LocaleFilesRepository $repo): int
+    {
+        $repo->saveLinkedPackages([]);
+        $this->info('Cleared all linked packages.');
+        return Command::SUCCESS;
+    }
+
+    private function invalidAction(string $action): int
+    {
+        $this->error("Unknown action: {$action}. Use list | add | remove | clear.");
+        return Command::INVALID;
     }
 }

--- a/src/Command/LinkedPackagesCommand.php
+++ b/src/Command/LinkedPackagesCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Condoedge\Utils\Command;
+
+use Illuminate\Console\Command;
+
+class LinkedPackagesCommand extends Command
+{
+    protected $signature = 'app:translator-packages
+                            {action=list : list | add | remove | clear}
+                            {path? : Filesystem path (required for add/remove)}';
+
+    protected $description = 'Manage local package paths scanned by the translation analyzer.';
+
+    public function handle(): int
+    {
+        $action = $this->argument('action');
+        $path = $this->argument('path');
+
+        $current = MissingTranslationAnalyzerCommand::loadLinkedPackages();
+
+        switch ($action) {
+            case 'list':
+                if (empty($current)) {
+                    $this->info('No linked packages.');
+                    return Command::SUCCESS;
+                }
+                $this->info('Linked packages:');
+                foreach ($current as $p) {
+                    $marker = is_dir($p) ? '✓' : '✗ (missing)';
+                    $this->line("  {$marker}  {$p}");
+                }
+                return Command::SUCCESS;
+
+            case 'add':
+                if (!$path) {
+                    $this->error('Provide a path: php artisan app:translator-packages add /path/to/package');
+                    return Command::INVALID;
+                }
+                $real = realpath($path);
+                if (!$real || !is_dir($real)) {
+                    $this->error("Not a directory: {$path}");
+                    return Command::INVALID;
+                }
+                $current[] = $real;
+                MissingTranslationAnalyzerCommand::saveLinkedPackages($current);
+                $this->info("Linked: {$real}");
+                return Command::SUCCESS;
+
+            case 'remove':
+                if (!$path) {
+                    $this->error('Provide a path: php artisan app:translator-packages remove /path/to/package');
+                    return Command::INVALID;
+                }
+                $target = realpath($path) ?: $path;
+                $filtered = array_values(array_filter($current, function ($p) use ($target) {
+                    return $p !== $target && realpath($p) !== $target;
+                }));
+                if (count($filtered) === count($current)) {
+                    $this->warn("Not found in linked list: {$path}");
+                    return Command::SUCCESS;
+                }
+                MissingTranslationAnalyzerCommand::saveLinkedPackages($filtered);
+                $this->info("Unlinked: {$target}");
+                return Command::SUCCESS;
+
+            case 'clear':
+                MissingTranslationAnalyzerCommand::saveLinkedPackages([]);
+                $this->info('Cleared all linked packages.');
+                return Command::SUCCESS;
+
+            default:
+                $this->error("Unknown action: {$action}. Use list | add | remove | clear.");
+                return Command::INVALID;
+        }
+    }
+}

--- a/src/Command/MarkMissingTranslationCommand.php
+++ b/src/Command/MarkMissingTranslationCommand.php
@@ -2,9 +2,9 @@
 
 namespace Condoedge\Utils\Command;
 
-use Condoedge\Utils\Models\MissingTranslation;
+use Condoedge\Utils\Services\Translation\MissingTranslationRecord;
+use Condoedge\Utils\Services\Translation\MissingTranslationsStore;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Cache;
 
 class MarkMissingTranslationCommand extends Command
 {
@@ -15,10 +15,15 @@ class MarkMissingTranslationCommand extends Command
 
     protected $description = 'Mark missing_translations rows as fixed or ignored (or reset) — used by the translator GUI.';
 
+    public function __construct(private readonly MissingTranslationsStore $store)
+    {
+        parent::__construct();
+    }
+
     public function handle(): int
     {
-        $keys = (array) $this->argument('keys');
-        $status = $this->option('status');
+        $keys    = (array) $this->argument('keys');
+        $status  = $this->option('status');
         $locales = (array) $this->option('locale');
 
         if (!in_array($status, ['fixed', 'ignored', 'reset'], true)) {
@@ -26,37 +31,26 @@ class MarkMissingTranslationCommand extends Command
             return Command::INVALID;
         }
 
-        $query = MissingTranslation::query()->whereIn('translation_key', $keys);
-        if (!empty($locales)) {
-            $query->whereIn('locale', $locales);
-        }
+        $matches = $this->store->query()
+            ->whereIn('translation_key', $keys)
+            ->when(!empty($locales), fn($q) => $q->whereIn('locale', $locales))
+            ->get();
 
-        $rows = $query->get();
-        if ($rows->isEmpty()) {
+        if ($matches->isEmpty()) {
             $this->warn('No matching rows.');
             return Command::SUCCESS;
         }
 
-        foreach ($rows as $row) {
+        foreach ($matches as $row) {
+            /** @var MissingTranslationRecord $row */
             match ($status) {
-                'fixed'   => $row->fixed_at = now(),
-                'ignored' => $row->ignored_at = now(),
-                'reset'   => [$row->fixed_at = null, $row->ignored_at = null],
+                'fixed'   => $this->store->markFixed($row->id),
+                'ignored' => $this->store->markIgnored($row->id),
+                'reset'   => $this->store->reset($row->id),
             };
-            $row->save(); // triggers the observer that clears the TrackingTranslator cache
         }
 
-        // Also clear any cache entries (belt & braces — the model observer does this
-        // but some wildcard entries may persist from the legacy single-key layout).
-        foreach ($keys as $key) {
-            Cache::forget('translation_missing_' . $key);
-            Cache::forget('translation_missing_' . $key . ':*');
-            foreach ($locales ?: [''] as $locale) {
-                Cache::forget('translation_missing_' . $key . ':' . ($locale ?: '*'));
-            }
-        }
-
-        $this->info("Marked {$rows->count()} row(s) as {$status}.");
+        $this->info("Marked {$matches->count()} row(s) as {$status}.");
         return Command::SUCCESS;
     }
 }

--- a/src/Command/MarkMissingTranslationCommand.php
+++ b/src/Command/MarkMissingTranslationCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Condoedge\Utils\Command;
+
+use Condoedge\Utils\Models\MissingTranslation;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+class MarkMissingTranslationCommand extends Command
+{
+    protected $signature = 'app:mark-missing-translation
+                            {keys* : One or more translation keys}
+                            {--status=fixed : fixed | ignored | reset}
+                            {--locale=* : Restrict to specific locales (default: all rows for the key)}';
+
+    protected $description = 'Mark missing_translations rows as fixed or ignored (or reset) — used by the translator GUI.';
+
+    public function handle(): int
+    {
+        $keys = (array) $this->argument('keys');
+        $status = $this->option('status');
+        $locales = (array) $this->option('locale');
+
+        if (!in_array($status, ['fixed', 'ignored', 'reset'], true)) {
+            $this->error("Invalid --status: {$status}. Use fixed, ignored, or reset.");
+            return Command::INVALID;
+        }
+
+        $query = MissingTranslation::query()->whereIn('translation_key', $keys);
+        if (!empty($locales)) {
+            $query->whereIn('locale', $locales);
+        }
+
+        $rows = $query->get();
+        if ($rows->isEmpty()) {
+            $this->warn('No matching rows.');
+            return Command::SUCCESS;
+        }
+
+        foreach ($rows as $row) {
+            match ($status) {
+                'fixed'   => $row->fixed_at = now(),
+                'ignored' => $row->ignored_at = now(),
+                'reset'   => [$row->fixed_at = null, $row->ignored_at = null],
+            };
+            $row->save(); // triggers the observer that clears the TrackingTranslator cache
+        }
+
+        // Also clear any cache entries (belt & braces — the model observer does this
+        // but some wildcard entries may persist from the legacy single-key layout).
+        foreach ($keys as $key) {
+            Cache::forget('translation_missing_' . $key);
+            Cache::forget('translation_missing_' . $key . ':*');
+            foreach ($locales ?: [''] as $locale) {
+                Cache::forget('translation_missing_' . $key . ':' . ($locale ?: '*'));
+            }
+        }
+
+        $this->info("Marked {$rows->count()} row(s) as {$status}.");
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/MissingTranslationAnalyzerCommand.php
+++ b/src/Command/MissingTranslationAnalyzerCommand.php
@@ -2,29 +2,35 @@
 
 namespace Condoedge\Utils\Command;
 
+use Condoedge\Utils\Services\Translation\ExcludedKeysRepository;
+use Condoedge\Utils\Services\Translation\KeyCodeScanner;
+use Condoedge\Utils\Services\Translation\LocaleFilesRepository;
+use Condoedge\Utils\Services\Translation\MissingTranslationCheckerInterface;
+use Condoedge\Utils\Services\Translation\ObsoleteKeyDetector;
+use Condoedge\Utils\Services\Translation\VendorTranslationMerger;
 use Illuminate\Console\Command;
-use Symfony\Component\Finder\Finder;
-use Condoedge\Utils\Services\Translation\TranslationKeyFilter;
 
 class MissingTranslationAnalyzerCommand extends Command
 {
     /**
-     * Map of translation keys to their file locations
-     *
-     * @var array
+     * Options for the --json report used by the default "missing keys" run.
+     * Kept UNESCAPED_SLASHES so file paths stay readable in the output.
      */
-    private $keyFileMap = [];
+    private const MISSING_JSON_OPTIONS = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
 
     /**
-     * Prefixes detected from dynamic translation calls.
-     * Any JSON key starting with one of these is assumed to be used dynamically.
-     *
-     * @var array<string, true>
+     * Options for sub-reports (empty values, obsolete keys, locale diff).
+     * Kept UNESCAPED_UNICODE so localized keys render verbatim.
      */
-    private $dynamicPrefixes = [];
+    private const SUBREPORT_JSON_OPTIONS = JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE;
 
-    /** @var TranslationKeyFilter|null */
-    private $keyFilter;
+    /**
+     * Per-key source locations populated by {@see extractAllTranslationKeys()}
+     * and consumed by {@see checkMissingTranslations()} / the output helpers.
+     *
+     * @var array<string, array<int, array{file:string, line:int, context:string}>>
+     */
+    private array $keyFileMap = [];
 
     /**
      * The name and signature of the console command.
@@ -52,694 +58,141 @@ class MissingTranslationAnalyzerCommand extends Command
      */
     protected $description = 'Analyze and find missing translation keys in the application';
 
-    /**
-     * Single source of truth: every callable that takes a translation key as first argument.
-     *
-     * Each entry describes ONE function; regexes for literal capture, named-arg capture,
-     * and dynamic-prefix extraction are all derived from this list.
-     *
-     *   'regex'       → regex fragment matching the callable name (with escaping done)
-     *   'named_arg'   → supports PHP 8 named args `func(key: '...')`
-     *   'lookbehind'  → extra negative lookbehind to avoid false opens (e.g. `$t` shouldn't match `foo$t`)
-     *   'multi_arg'   → the key is followed by other args (e.g. `trans_choice('key', $n)`)
-     */
-    private const TRANSLATION_FUNCTIONS = [
-        ['regex' => '__',                                                     'named_arg' => true,  'lookbehind' => ''],
-        ['regex' => 'trans',                                                  'named_arg' => true,  'lookbehind' => '(?<![a-zA-Z])'],
-        ['regex' => 'trans_choice',                                           'named_arg' => true,  'lookbehind' => '',              'multi_arg' => true],
-        ['regex' => '@lang',                                                  'named_arg' => false, 'lookbehind' => ''],
-        ['regex' => 'Lang::get',                                              'named_arg' => false, 'lookbehind' => ''],
-        ['regex' => '\$this->translator',                                     'named_arg' => false, 'lookbehind' => ''],
-        ['regex' => '_[A-Z][a-zA-Z]+',                                        'named_arg' => false, 'lookbehind' => '', 'multi_arg' => true],
-        ['regex' => '_',                                                      'named_arg' => false, 'lookbehind' => '(?<![a-zA-Z])'], // gettext-style
-        ['regex' => '\$t',                                                    'named_arg' => false, 'lookbehind' => '(?<![a-zA-Z])'], // Vue
-        ['regex' => 'i18n\.t',                                                'named_arg' => false, 'lookbehind' => '(?<![a-zA-Z])'], // Vue-i18n
-        ['regex' => 'throwValidationError\s*\(\s*[\'"][^\'"]+[\'"]\s*,\s*',   'named_arg' => false, 'lookbehind' => '',               'is_raw_prefix' => true],
-    ];
+    public function __construct(
+        private readonly KeyCodeScanner $scanner,
+        private readonly LocaleFilesRepository $localeFiles,
+        private readonly MissingTranslationCheckerInterface $missingChecker,
+        private readonly ExcludedKeysRepository $excludedKeys,
+        private readonly ObsoleteKeyDetector $obsoleteDetector,
+        private readonly VendorTranslationMerger $vendorMerger,
+    ) {
+        parent::__construct();
+    }
 
     /**
-     * Extra literal patterns that aren't function calls (PHP properties, Vue directives, array values, …).
+     * Execute the console command. Options are mutually exclusive — the first
+     * matching branch wins; the final arm is the default "check missing" flow.
      */
-    private const EXTRA_LITERAL_PATTERNS = [
-        'titles'             => '/protected\s+\$_Title\s*=\s*[\'"](.+?)[\'"]\s*;/u',
-        'vue_directive_t'    => '/v-t\s*=\s*[\'"]([^\'"]+)[\'"]/u',
-        'array_value'        => '/=>\s*[\'"]([a-z][a-z0-9_-]*\.[a-z][a-z0-9._-]*)[\'"]/iu',
-    ];
-
-    /**
-     * File exclusion configuration
-     */
-    private const FILE_EXCLUSIONS = [
-        'files' => [
-            'composer.lock', 'package-lock.json', 'yarn.lock', 'webpack.mix.js',
-            'tailwind.config.js', 'vite.config.js', '_ide_helper.php', 'server.php', 'artisan'
-        ],
-        'patterns' => [
-            '/\.min\.(js|css)$/', '/\.lock$/', '/Test\.php$/', '/_test\.php$/',
-            '/Migration\.php$/', '/Seeder\.php$/', '/Factory\.php$/'
-        ],
-        'paths' => [
-            '/vendor/', '/node_modules/', '/storage/', '/bootstrap/cache/',
-            '/public/build/', '/public/hot'
-        ]
-    ];
-
-    /**
-     * File-like extensions to treat as filenames and ignore as translation keys
-     */
-    private const FILE_LIKE_EXTENSIONS = [
-        'txt', 'pdf', 'xlsx', 'xls', 'csv',
-        'doc', 'docx', 'ppt', 'pptx',
-        'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp',
-        'zip', 'rar', 'tar', 'gz', '7z',
-        'mp3', 'mp4', 'mov', 'avi', 'mkv', 'webm',
-        'log', 'md', 'json', 'xml', 'html', 'htm', 'css', 'js', 'ts',
-        'yml', 'yaml', 'ini'
-    ];
-
-    /**
-     * Execute the console command.
-     */
-    public function handle()
+    public function handle(): void
     {
-        if ($this->option('show-excluded')) {
-            $this->showExcludedKeys();
-            return;
-        }
+        match (true) {
+            $this->option('show-excluded')          => $this->showExcludedKeys(),
+            $this->option('reset-excluded')         => $this->resetExcludedKeys(),
+            (bool) $this->option('exclude-key')     => $this->addToExcludeList((array) $this->option('exclude-key')),
+            $this->option('merge-vendor')           => $this->mergeVendorTranslations(),
+            $this->option('check-empty-values')     => $this->checkEmptyValues(),
+            $this->option('check-obsolete')         => $this->checkObsoleteKeys($this->extractAllTranslationKeys()),
+            $this->option('diff-locales')           => $this->diffLocales(),
+            default                                 => $this->runDefaultMissingCheck(),
+        };
+    }
 
-        if ($this->option('reset-excluded')) {
-            $this->resetExcludedKeys();
-            return;
-        }
-
-        if ($excludeKeys = $this->option('exclude-key')) {
-            $this->addToExcludeList($excludeKeys);
-            return;
-        }
-
-        if ($this->option('merge-vendor')) {
-            $this->mergeVendorTranslations();
-            return;
-        }
-
-        if ($this->option('check-empty-values')) {
-            $this->checkEmptyValues();
-            return;
-        }
-
-        if ($this->option('check-obsolete')) {
-            $keys = $this->extractAllTranslationKeys();
-            $this->checkObsoleteKeys($keys);
-            return;
-        }
-
-        if ($this->option('diff-locales')) {
-            $this->diffLocales();
-            return;
-        }
-
+    private function runDefaultMissingCheck(): void
+    {
         $keys = $this->extractAllTranslationKeys();
         $this->indexKeys($keys);
         $this->checkMissingTranslations($keys);
     }
     
-    private function extractAllTranslationKeys()
+    private function extractAllTranslationKeys(): array
     {
-        $linkedPackages = $this->loadLinkedPackages();
-
-        $finder = new Finder();
-        $finder->files()
-            ->in(base_path())
-            ->name('*.php')
-            ->name('*.blade.php')
-            ->name('*.vue')
-            ->name('*.js')
-            ->name('*.ts')
-            ->exclude('node_modules')
-            ->exclude('storage')
-            ->exclude('bootstrap/cache')
-            ->exclude('public')
-            ->notName('*.lock')
-            ->notName('*.min.js')
-            ->notName('*.min.css')
-            ->notPath('*/migrations/*')
-            ->notPath('*/seeders/*')
-            ->notPath('*/factories/*')
-            ->notPath('*/tests/*')
-            ->notPath('*/Test*')
-            ->notPath('*/_ide_helper*')
-            ->notPath('*/config/cache/*')
-            ->notPath('*/lang/*')
-            ->notPath('*/resources/lang/*');
-
-        // Add any user-linked local packages (folders outside base_path()) as additional roots.
-        foreach ($linkedPackages as $path) {
-            if (is_dir($path)) {
-                $finder->in($path);
-            }
-        }
-
-        $linkedRealPaths = array_filter(array_map('realpath', $linkedPackages));
-
-        $files = $finder->filter(function (\SplFileInfo $file) use ($linkedRealPaths) {
-            $path = $file->getRealPath();
-
-            // Files inside a user-linked package are always included.
-            foreach ($linkedRealPaths as $linked) {
-                if ($linked && strpos($path, $linked . DIRECTORY_SEPARATOR) === 0) {
-                    return true;
-                }
-            }
-
-            // If file is not in vendor, include it
-            if (strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR) === false) {
-                return true;
-            }
-
-            // If file is in vendor/condoedge or vendor/kompo, include it
-            if (strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'condoedge' . DIRECTORY_SEPARATOR) !== false ||
-                strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'kompo' . DIRECTORY_SEPARATOR) !== false) {
-                return true;
-            }
-
-            // Exclude all other vendor files
-            return false;
-        });
-
-        $keys = [];
-        $this->keyFileMap = []; // Store key to file mappings
-
-        foreach ($files as $file) {
-            // Skip files that shouldn't contain translations
-            if ($this->shouldSkipFile($file->getFilename(), $file->getRealPath())) {
-                continue;
-            }
-
-            $content = file_get_contents($file->getRealPath());
-            $this->collectDynamicPrefixes($content);
-            $fileKeys = $this->extractKeysFromContent($content, $file->getRealPath());
-
-            foreach ($fileKeys as $keyData) {
-                $key = $keyData['key'];
-                $keys[] = $key;
-
-                // Store file location and context for each key
-                if (!isset($this->keyFileMap[$key])) {
-                    $this->keyFileMap[$key] = [];
-                }
-                $this->keyFileMap[$key][] = [
-                    'file' => str_replace(base_path() . DIRECTORY_SEPARATOR, '', $file->getRealPath()),
-                    'line' => $keyData['line'],
-                    'context' => $keyData['context']
-                ];
-            }
-        }
-
-        return array_unique($keys);
+        $result = $this->scanner->scan(
+            $this->localeFiles->linkedPackages(),
+            (bool) $this->option('universal-detection'),
+            (bool) $this->option('include-plain-text'),
+        );
+        $this->keyFileMap = $result['locations'];
+        return $result['keys'];
     }
 
-    private function indexKeys($keys)
+    private function indexKeys(array $keys): void
     {
         $this->info("Indexing " . count($keys) . " translation keys...");
-    
-        // Store in cache for quick access
-        cache(['translation_keys' => $keys], now()->addDay());
-        
-        // Also save to file for reference
-        file_put_contents(
-            storage_path('app/translation_keys.json'), 
-            json_encode($keys, JSON_PRETTY_PRINT)
-        );
+        $this->localeFiles->indexKeys($keys);
     }
 
-    private function checkMissingTranslations($keys)
+    private function checkMissingTranslations(array $keys): void
     {
-        $locales = $this->resolveLocales();
-        $missing = [];
-
         if (!$this->option('json')) {
-            $this->info("Total translation keys found: " . count($keys));
+            $this->info('Total translation keys found: ' . count($keys));
         }
 
-        // Pre-fetch rows that were explicitly ignored or fixed — we skip them in the report
-        // so the GUI/CLI never re-propose keys the user has already triaged.
-        $skipGlobal = [];     // key → true (when triaged with no specific locale)
-        $skipPerLocale = [];  // key → [locale => true]
+        $locales = $this->resolveLocales();
+        $missingByLocale = $this->missingChecker->find(
+            $keys,
+            $locales,
+            (bool) $this->option('include-triaged')
+        );
 
-        if (!$this->option('include-triaged')) {
-            $triagedRows = \Condoedge\Utils\Models\MissingTranslation::query()
-                ->whereIn('translation_key', $keys)
-                ->where(function ($q) {
-                    $q->whereNotNull('ignored_at')->orWhereNotNull('fixed_at');
-                })
-                ->get(['translation_key', 'locale', 'ignored_at', 'fixed_at']);
-
-            foreach ($triagedRows as $row) {
-                if (empty($row->locale)) {
-                    $skipGlobal[$row->translation_key] = true;
-                } else {
-                    $skipPerLocale[$row->translation_key][$row->locale] = true;
-                }
-            }
-        }
-
-        foreach ($locales as $locale) {
+        $report = [];
+        foreach ($missingByLocale as $locale => $missingKeys) {
             if (!$this->option('json')) {
                 $this->info("Checking translations for locale: {$locale}");
             }
-
-            foreach ($keys as $key) {
-                if (isset($skipGlobal[$key]) || isset($skipPerLocale[$key][$locale])) {
-                    continue;
-                }
-                if (!$this->hasTranslation($key, $locale)) {
-                    $locations = $this->keyFileMap[$key] ?? [];
-
-                    $missingData = [
-                        'key' => $key,
-                        'locations' => $locations
-                    ];
-                    $missing[$locale][] = $missingData;
-                    
-                    // Save to MissingTranslation table with file locations
-                    try {
-                        $firstLocation = !empty($locations) ? $locations[0] : null;
-                        $filename = $firstLocation['file'] ?? null;
-
-                        if ($filename && str_contains($filename, 'MissingTranslationAnalyzerCommand')) {
-                            $filename = null;
-                        }
-
-                        \Condoedge\Utils\Models\MissingTranslation::upsertMissingTranslation(
-                            $key,
-                            $filename,
-                            $locale,
-                            $filename
-                        );
-                    } catch (\Exception $e) {
-                        // Silently continue if database save fails
-                    }
-                }
+            foreach ($missingKeys as $key) {
+                $locations = $this->keyFileMap[$key] ?? [];
+                $report[$locale][] = ['key' => $key, 'locations' => $locations];
+                $this->persistMissing($key, $locale, $locations);
             }
         }
 
         if ($this->option('json')) {
-            $this->outputJson($missing);
-        } else {
-            $this->displayMissingTranslations($missing);
+            $this->outputJson($report);
+            return;
+        }
 
-            // Ask if user wants to add some keys to exclusion list
-            if (!empty($missing)) {
-                $this->info("\nWant to add some keys to the exclusion list?");
-                $this->info("You can edit the file: " . storage_path('app/translation_exclude_keys.json'));
-            }
+        $this->displayMissingTranslations($report);
+        if (!empty($report)) {
+            $this->info("\nWant to add some keys to the exclusion list?");
+            $this->info('You can edit the file: ' . storage_path('app/translation_exclude_keys.json'));
         }
     }
+
+    private function persistMissing(string $key, string $locale, array $locations): void
+    {
+        try {
+            $filename = $locations[0]['file'] ?? null;
+            if ($filename && str_contains($filename, 'MissingTranslationAnalyzerCommand')) {
+                $filename = null;
+            }
+            \Condoedge\Utils\Models\MissingTranslation::upsertMissingTranslation($key, $filename, $locale, $filename);
+        } catch (\Throwable $e) {
+            // Silently continue if DB save fails — JSON is the source of truth.
+        }
+    }
+
     private function resolveLocales(): array
     {
-        $cli = (array) $this->option('locale');
-        if (!empty($cli)) {
-            return $cli;
-        }
-
-        $configured = config('app.supported_locales');
-        if (is_array($configured) && !empty($configured)) {
-            return $configured;
-        }
-
-        return ['en', 'fr'];
+        return $this->localeFiles->resolveLocales((array) $this->option('locale'));
     }
 
-    private function hasTranslation($key, $locale)
+    private function addToExcludeList(array $keys): void
     {
-        app()->setLocale($locale);
-
-        if (!\Lang::has($key, $locale)) {
-            return false;
-        }
-
-        // A key can be present with an empty or self-referencing value — still effectively untranslated.
-        $value = \Lang::get($key, [], $locale);
-
-        if (!is_string($value)) {
-            return true;
-        }
-
-        $trimmed = trim($value);
-
-        if ($trimmed === '' || $trimmed === $key) {
-            return false;
-        }
-
-        return true;
-    }
-   
-    /**
-     * Build all literal-capture regex patterns from the TRANSLATION_FUNCTIONS list + EXTRA_LITERAL_PATTERNS.
-     */
-    private function buildLiteralPatterns(): array
-    {
-        $patterns = [];
-
-        foreach (self::TRANSLATION_FUNCTIONS as $fn) {
-            $head = $fn['lookbehind'] . $fn['regex'];
-            $closing = !empty($fn['multi_arg']) ? '[),]' : '\)';
-
-            if (!empty($fn['is_raw_prefix'])) {
-                // Raw-prefix entries already include the arg list before the key; no opening paren added.
-                $patterns[$fn['regex']] = '/' . $head . '[\'"]([^\'"]+)[\'"]/u';
-                continue;
-            }
-
-            // Standard positional form: func('key'...)
-            $patterns[$fn['regex']] = '/' . $head . '\s*\(\s*[\'"]([^\'"]+)[\'"]\s*' . $closing . '/u';
-
-            if (!empty($fn['named_arg'])) {
-                // Named-arg form: func(key: 'key', ...)
-                $patterns[$fn['regex'] . '__named'] = '/' . $head . '\s*\(\s*key:\s*[\'"]([^\'"]+)[\'"]\s*[,)]/u';
-            }
-        }
-
-        foreach (self::EXTRA_LITERAL_PATTERNS as $name => $pattern) {
-            $patterns[$name] = $pattern;
-        }
-
-        return $patterns;
+        $added = $this->excludedKeys->add($keys);
+        $this->info("Added {$added} key(s) to exclusion list.");
     }
 
-    /**
-     * Build all dynamic-prefix extraction regex patterns from the TRANSLATION_FUNCTIONS list.
-     */
-    private function buildDynamicPatterns(): array
+    private function showExcludedKeys(): void
     {
-        $patterns = [];
-
-        foreach (self::TRANSLATION_FUNCTIONS as $fn) {
-            if (!empty($fn['is_raw_prefix'])) {
-                continue; // meaningless for throwValidationError-style (key is 2nd arg, rarely dynamic)
-            }
-
-            $head = $fn['lookbehind'] . $fn['regex'];
-
-            // Interpolation form inside double-quoted: capture static head before $ or {$
-            $patterns[] = '/' . $head . '\s*\(\s*["]([a-zA-Z][a-zA-Z0-9._-]*\.)[^"]*(?:\$|\{\$)/u';
-            // Concatenation form: static head followed by dot-concat with a variable
-            $patterns[] = '/' . $head . '\s*\(\s*[\'"]([a-zA-Z][a-zA-Z0-9._-]*\.)[\'"]\s*\./u';
-        }
-
-        return $patterns;
-    }
-
-    /**
-     * Universal detection: every quoted literal that LOOKS like a translation key.
-     *
-     * Opt-in via --universal-detection. Scoped to UI files only (see isUiFile).
-     * A "translation-looking" key is:
-     *   - at least 2 chars long
-     *   - starts with a letter
-     *   - contains only [a-zA-Z0-9._-]
-     *   - contains at least one '.' OR one '-' (otherwise it's likely a single common word)
-     *
-     * Routes config, class names, database column names are skipped because the scope
-     * excludes routes/, config/, database/ from this pass.
-     */
-    /**
-     * Requires at least one '.' — flat dash keys like "alert-triangle", "arrow-down" are too noisy
-     * (icons, HTML IDs, CSS classes, HTTP headers). Flat keys are already captured by standard
-     * regex when passed to helpers like _Html('accept-invitation').
-     */
-    private const UNIVERSAL_KEY_REGEX = '/[\'"]([a-z][a-zA-Z0-9_-]*\.[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])[\'"]/u';
-
-    /**
-     * Paths that look like UI code (where translation calls are expected).
-     * Used only when --universal-detection is enabled to keep false positives low.
-     */
-    private const UI_PATH_MARKERS = [
-        '/Kompo/',
-        '/Livewire/',
-        '/Filament/',
-        '/Components/',
-        DIRECTORY_SEPARATOR . 'resources' . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR,
-        DIRECTORY_SEPARATOR . 'resources' . DIRECTORY_SEPARATOR . 'js' . DIRECTORY_SEPARATOR,
-    ];
-
-    /**
-     * Paths explicitly excluded from universal detection (non-UI concerns).
-     */
-    private const UNIVERSAL_EXCLUDE_PATHS = [
-        DIRECTORY_SEPARATOR . 'routes' . DIRECTORY_SEPARATOR,
-        DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR,
-        DIRECTORY_SEPARATOR . 'database' . DIRECTORY_SEPARATOR,
-        DIRECTORY_SEPARATOR . 'bootstrap' . DIRECTORY_SEPARATOR,
-        DIRECTORY_SEPARATOR . 'Console' . DIRECTORY_SEPARATOR,
-        DIRECTORY_SEPARATOR . 'Exceptions' . DIRECTORY_SEPARATOR,
-        DIRECTORY_SEPARATOR . 'Middleware' . DIRECTORY_SEPARATOR,
-        DIRECTORY_SEPARATOR . 'Providers' . DIRECTORY_SEPARATOR,
-        DIRECTORY_SEPARATOR . 'Jobs' . DIRECTORY_SEPARATOR,
-        DIRECTORY_SEPARATOR . 'Listeners' . DIRECTORY_SEPARATOR,
-        DIRECTORY_SEPARATOR . 'Observers' . DIRECTORY_SEPARATOR,
-    ];
-
-    private function isUiFile(string $realPath, string $content): bool
-    {
-        $normalized = str_replace('\\', '/', $realPath);
-        $normalizedForExclude = $realPath;
-
-        foreach (self::UNIVERSAL_EXCLUDE_PATHS as $excluded) {
-            if (strpos($normalizedForExclude, $excluded) !== false) {
-                return false;
-            }
-        }
-
-        // Blade and Vue are always UI
-        if (str_ends_with($normalized, '.blade.php') || str_ends_with($normalized, '.vue')) {
-            return true;
-        }
-
-        foreach (self::UI_PATH_MARKERS as $marker) {
-            if (strpos($normalized, str_replace('\\', '/', $marker)) !== false) {
-                return true;
-            }
-        }
-
-        // Enums with label() method often hold UI-facing literals
-        if (preg_match('/enum\s+\w+[^{]*\{[^}]*function\s+label\s*\(/', $content)) {
-            return true;
-        }
-
-        return false;
-    }
-
-    private function extractKeysFromContent($content, $filepath = '')
-    {
-        if ($this->shouldSkipContent($content)) {
-            return [];
-        }
-
-        $keys = [];
-        $lines = explode("\n", $content);
-        $patterns = $this->buildLiteralPatterns();
-
-        foreach ($patterns as $name => $pattern) {
-            if (preg_match_all($pattern, $content, $matches, PREG_OFFSET_CAPTURE)) {
-                foreach ($matches[1] as $match) {
-                    $key = trim($match[0]);
-                    $offset = $match[1];
-
-                    // Find line number from offset
-                    $lineNumber = substr_count(substr($content, 0, $offset), "\n") + 1;
-
-                    // Get context (surrounding lines)
-                    $contextStart = max(0, $lineNumber - 3);
-                    $contextEnd = min(count($lines), $lineNumber + 2);
-                    $contextLines = array_slice($lines, $contextStart, $contextEnd - $contextStart);
-                    $context = implode("\n", $contextLines);
-
-                    if ($this->isValidTranslationKey($key, $content, $key)) {
-                        $keys[] = [
-                            'key' => $key,
-                            'line' => $lineNumber,
-                            'context' => $context
-                        ];
-                    }
-                }
-            }
-        }
-
-        // Optional pass 2 — universal detection, UI-scoped.
-        if ($this->option('universal-detection') && $filepath && $this->isUiFile($filepath, $content)) {
-            if (preg_match_all(self::UNIVERSAL_KEY_REGEX, $content, $matches, PREG_OFFSET_CAPTURE)) {
-                foreach ($matches[1] as $match) {
-                    $key = trim($match[0]);
-                    $offset = $match[1];
-                    $lineNumber = substr_count(substr($content, 0, $offset), "\n") + 1;
-                    $contextStart = max(0, $lineNumber - 3);
-                    $contextEnd = min(count($lines), $lineNumber + 2);
-                    $contextLines = array_slice($lines, $contextStart, $contextEnd - $contextStart);
-                    $context = implode("\n", $contextLines);
-
-                    if ($this->isValidTranslationKey($key, $content, $key)) {
-                        $keys[] = [
-                            'key' => $key,
-                            'line' => $lineNumber,
-                            'context' => $context
-                        ];
-                    }
-                }
-            }
-        }
-
-        return $keys;
-    }
-
-    private function getMatchContext($content, $match)
-    {
-        // Narrow window BEFORE the match only: context-based exclusions are meant to catch
-        // the immediate wrapping function call (e.g. `config('some.key')`), not unrelated nearby code.
-        $position = strpos($content, $match);
-        if ($position === false) {
-            return '';
-        }
-        $start = max(0, $position - 40);
-        $length = $position - $start;
-
-        return substr($content, $start, $length);
-    }
-
-    private function isValidTranslationKey($key, $content = '', $matchedText = '')
-    {
-        $context = $matchedText ? $this->getMatchContext($content, $matchedText) : '';
-        return $this->getKeyFilter()->isValidKey($key, $context);
-    }
-
-    private function getKeyFilter(): TranslationKeyFilter
-    {
-        if (!$this->keyFilter) {
-            $this->keyFilter = new TranslationKeyFilter();
-            $this->keyFilter->allowPlainText = (bool) $this->option('include-plain-text');
-        }
-        return $this->keyFilter;
-    }
-    
-    private function shouldSkipFile($filename, $filepath)
-    {
-        $exclusions = self::FILE_EXCLUSIONS;
-
-        // Check specific files
-        if (in_array($filename, $exclusions['files'])) {
-            return true;
-        }
-
-        // Check file patterns
-        foreach ($exclusions['patterns'] as $pattern) {
-            if (preg_match($pattern, $filename)) {
-                return true;
-            }
-        }
-
-        // Check paths
-        foreach ($exclusions['paths'] as $path) {
-            if (strpos($filepath, $path) !== false) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-    
-    private function shouldSkipContent($content)
-    {
-        $skipPatterns = [
-            '/composer\.lock/', '/node_modules/', '/vendor\/\//',
-            '/^\s*\/\*\*/', 
-        ];
-        
-        foreach ($skipPatterns as $pattern) {
-            if (preg_match($pattern, $content)) {
-                return true;
-            }
-        }
-        
-        return false;
-    }
-    
-    private function isExcludedKey($key)
-    {
-        // Load excluded keys from file if exists
-        $excludedKeys = $this->getExcludedKeys();
-        
-        return in_array($key, $excludedKeys);
-    }
-    
-    private function getExcludedKeys()
-    {
-        $excludeFile = storage_path('app/translation_exclude_keys.json');
-        
-        if (file_exists($excludeFile)) {
-            $content = file_get_contents($excludeFile);
-            return json_decode($content, true) ?: [];
-        }
-
-        // Default keys to exclude - common function names and framework-specific terms
-        $defaultExcluded = [
-            // Framework/Helper functions
-            '_CollapsibleSideSection', '_CollapsibleInnerSection', '_CollapsibleSideTitle', '_CollapsibleSideItem',
-            '_Button', '_Link', '_Flex', '_Html', '_Sax', '_Collapsible',
-            
-            // Common attributes/properties
-            'class', 'id', 'href', 'src', 'alt', 'title', 'name', 'value', 'type',
-            
-            // Technical terms
-            'php', 'js', 'css', 'html', 'json', 'xml', 'api', 'admin',
-            
-            // States/values
-            'hidden', 'active', 'disabled', 'loading', 'home', 'login', 'logout'
-        ];
-        
-        // Create exclusion file if it doesn't exist
-        if (!file_exists($excludeFile)) {
-            file_put_contents($excludeFile, json_encode($defaultExcluded, JSON_PRETTY_PRINT));
-        }
-        
-        return $defaultExcluded;
-    }
-    
-    private function addToExcludeList($keys)
-    {
-        $excludeFile = storage_path('app/translation_exclude_keys.json');
-        $currentExcluded = $this->getExcludedKeys();
-        
-        $newExcluded = array_unique(array_merge($currentExcluded, (array)$keys));
-        
-        file_put_contents($excludeFile, json_encode($newExcluded, JSON_PRETTY_PRINT));
-        
-        $this->info("Added " . count((array)$keys) . " keys to exclusion list.");
-    }
-    
-    private function showExcludedKeys()
-    {
-        $excluded = $this->getExcludedKeys();
-        $this->info("Currently excluded keys (" . count($excluded) . "):");
+        $excluded = $this->excludedKeys->all();
+        $this->info('Currently excluded keys (' . count($excluded) . '):');
         foreach ($excluded as $key) {
             $this->line("  - {$key}");
         }
     }
-    
-    private function resetExcludedKeys()
+
+    private function resetExcludedKeys(): void
     {
-        $excludeFile = storage_path('app/translation_exclude_keys.json');
-        if (file_exists($excludeFile)) {
-            unlink($excludeFile);
-        }
-        $this->info("Exclusion list reset to default values.");
+        $this->excludedKeys->reset();
+        $this->info('Exclusion list reset to default values.');
     }
     
-    private function outputJson($missing)
+    private function outputJson(array $missing): void
     {
-        echo json_encode($missing, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        echo json_encode($missing, self::MISSING_JSON_OPTIONS);
     }
 
-    private function displayMissingTranslations($missing)
+    private function displayMissingTranslations(array $missing): void
     {
         foreach ($missing as $locale => $items) {
             if (!empty($items)) {
@@ -755,99 +208,12 @@ class MissingTranslationAnalyzerCommand extends Command
         }
     }
 
-    /**
-     * Detect dynamic translation calls and extract their literal prefix.
-     *
-     * Examples (backticks used in examples to avoid self-matching on this file):
-     *   `__(<ns>.$var)`    →  extracts the static prefix before the interpolation
-     *   `__(<ns>. . $var)` →  extracts the static prefix before the concatenation
-     *
-     * Pure variable calls like `__(<var>)` are deliberately IGNORED — they have no
-     * static prefix so we can't derive any safe namespace to whitelist; those cases
-     * remain a known blind spot.
-     */
-    private function collectDynamicPrefixes(string $content): void
-    {
-        foreach ($this->buildDynamicPatterns() as $pattern) {
-            if (preg_match_all($pattern, $content, $matches)) {
-                foreach ($matches[1] as $prefix) {
-                    $this->dynamicPrefixes[$prefix] = true;
-                }
-            }
-        }
-    }
-
-    private function hasDynamicPrefix(string $key): bool
-    {
-        foreach (array_keys($this->dynamicPrefixes) as $prefix) {
-            if (str_starts_with($key, $prefix)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Load additional local package paths the user wants scanned for translation keys.
-     * File: storage/app/translator_linked_packages.json (JSON array of absolute paths).
-     */
-    public static function loadLinkedPackages(): array
-    {
-        $path = storage_path('app/translator_linked_packages.json');
-        if (!is_file($path)) {
-            return [];
-        }
-        $decoded = json_decode(file_get_contents($path), true);
-        if (!is_array($decoded)) {
-            return [];
-        }
-        return array_values(array_filter($decoded, fn($p) => is_string($p) && $p !== ''));
-    }
-
-    public static function saveLinkedPackages(array $paths): void
-    {
-        $path = storage_path('app/translator_linked_packages.json');
-        @mkdir(dirname($path), 0755, true);
-        file_put_contents(
-            $path,
-            json_encode(array_values(array_unique($paths)), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n"
-        );
-    }
-
-    private function loadLocaleJson(string $locale): array
-    {
-        $path = resource_path("lang/{$locale}.json");
-        if (!file_exists($path)) {
-            return [];
-        }
-        return json_decode(file_get_contents($path), true) ?: [];
-    }
-
     private function checkEmptyValues(): void
     {
-        $locales = $this->resolveLocales();
-        $report = [];
-
-        foreach ($locales as $locale) {
-            $data = $this->loadLocaleJson($locale);
-            $empty = [];
-            $selfRef = [];
-
-            foreach ($data as $key => $value) {
-                if (!is_string($value)) continue;
-                $trimmed = trim($value);
-                if ($trimmed === '') {
-                    $empty[] = $key;
-                } elseif ($trimmed === $key) {
-                    $selfRef[] = $key;
-                }
-            }
-
-            $report[$locale] = ['empty' => $empty, 'self_ref' => $selfRef];
-        }
+        $report = $this->localeFiles->emptyValuesReport($this->resolveLocales());
 
         if ($this->option('json')) {
-            echo json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+            echo json_encode($report, self::SUBREPORT_JSON_OPTIONS);
             return;
         }
 
@@ -863,50 +229,17 @@ class MissingTranslationAnalyzerCommand extends Command
 
     private function checkObsoleteKeys(array $usedKeys): void
     {
-        $locales = $this->resolveLocales();
-        $usedSet = array_flip($usedKeys);
-        $report = [];
-
-        // Build candidate lists per locale.
-        $candidatesPerLocale = [];
-        $allCandidates = [];
-        $skippedByDynamicPrefix = 0;
-        foreach ($locales as $locale) {
-            $data = $this->loadLocaleJson($locale);
-            $candidates = [];
-            foreach (array_keys($data) as $key) {
-                if (isset($usedSet[$key])) {
-                    continue;
-                }
-                if ($this->hasDynamicPrefix($key)) {
-                    $skippedByDynamicPrefix++;
-                    continue;
-                }
-                $candidates[] = $key;
-                $allCandidates[$key] = true;
-            }
-            $candidatesPerLocale[$locale] = $candidates;
-        }
-
-        // Second pass: literal-string grep across code. A key is "really obsolete"
-        // only if nowhere in the codebase it appears as a quoted string.
-        $reallyObsolete = $this->filterByLiteralGrep(array_keys($allCandidates));
-
-        foreach ($candidatesPerLocale as $locale => $candidates) {
-            $report[$locale] = array_values(array_intersect($candidates, $reallyObsolete));
-        }
+        $result = $this->obsoleteDetector->detect($usedKeys, $this->resolveLocales());
+        $report = $result['report'];
 
         if ($this->option('json')) {
-            echo json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+            echo json_encode($report, self::SUBREPORT_JSON_OPTIONS);
             return;
         }
 
-        $rescued = count($allCandidates) - count($reallyObsolete);
-        $prefixes = array_keys($this->dynamicPrefixes);
-        sort($prefixes);
-        $this->info("Dynamic prefixes detected (" . count($prefixes) . "): " . implode(', ', $prefixes));
-        $this->info("Skipped {$skippedByDynamicPrefix} candidate keys matching dynamic prefixes.");
-        $this->info("Literal-grep pass rescued {$rescued} more keys (found as quoted strings elsewhere in code).");
+        $this->info("Dynamic prefixes detected (" . count($result['prefixes']) . "): " . implode(', ', $result['prefixes']));
+        $this->info("Skipped {$result['skippedByDynamicPrefix']} candidate keys matching dynamic prefixes.");
+        $this->info("Literal-grep pass rescued {$result['rescued']} more keys (found as quoted strings elsewhere in code).");
         $this->line('');
 
         foreach ($report as $locale => $keys) {
@@ -916,67 +249,12 @@ class MissingTranslationAnalyzerCommand extends Command
         }
     }
 
-    private function filterByLiteralGrep(array $candidates): array
-    {
-        if (empty($candidates)) {
-            return [];
-        }
-
-        // Read every scanned file ONCE into memory, then check each candidate via str_contains.
-        $finder = new Finder();
-        $files = $finder->files()
-            ->in(base_path())
-            ->name('*.php')->name('*.blade.php')->name('*.vue')->name('*.js')->name('*.ts')
-            ->exclude('node_modules')->exclude('storage')->exclude('bootstrap/cache')->exclude('public')
-            ->notName('*.lock')->notName('*.min.js')->notName('*.min.css')
-            ->notPath('*/lang/*')->notPath('*/resources/lang/*')
-            ->filter(function (\SplFileInfo $file) {
-                $path = $file->getRealPath();
-                if (strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR) === false) return true;
-                if (strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'condoedge' . DIRECTORY_SEPARATOR) !== false) return true;
-                if (strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'kompo' . DIRECTORY_SEPARATOR) !== false) return true;
-                return false;
-            });
-
-        $haystack = '';
-        foreach ($files as $file) {
-            $haystack .= file_get_contents($file->getRealPath()) . "\n";
-        }
-
-        $reallyObsolete = [];
-        foreach ($candidates as $key) {
-            // Look for the key wrapped in single OR double quotes (literal string usage).
-            if (
-                strpos($haystack, "'" . $key . "'") === false
-                && strpos($haystack, '"' . $key . '"') === false
-            ) {
-                $reallyObsolete[] = $key;
-            }
-        }
-
-        return $reallyObsolete;
-    }
-
     private function diffLocales(): void
     {
-        $locales = $this->resolveLocales();
-        $data = [];
-
-        foreach ($locales as $locale) {
-            $data[$locale] = array_keys($this->loadLocaleJson($locale));
-        }
-
-        $report = [];
-        foreach ($locales as $locale) {
-            $others = array_diff($locales, [$locale]);
-            foreach ($others as $other) {
-                $diffKey = "{$locale}_not_in_{$other}";
-                $report[$diffKey] = array_values(array_diff($data[$locale], $data[$other]));
-            }
-        }
+        $report = $this->localeFiles->diffLocalesReport($this->resolveLocales());
 
         if ($this->option('json')) {
-            echo json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+            echo json_encode($report, self::SUBREPORT_JSON_OPTIONS);
             return;
         }
 
@@ -987,82 +265,28 @@ class MissingTranslationAnalyzerCommand extends Command
         }
     }
 
-    private function mergeVendorTranslations()
+    private function mergeVendorTranslations(): void
     {
         $this->info("Merging vendor package translations...");
 
-        $vendorPaths = [
-            'vendor/condoedge',
-            'vendor/kompo'
-        ];
+        $report = $this->vendorMerger->merge();
 
-        $locales = ['en', 'fr'];
-        $mergedTranslations = [];
-
-        foreach ($locales as $locale) {
-            $mergedTranslations[$locale] = [];
+        foreach ($report['missingPaths'] as $missing) {
+            $this->warn("Vendor path not found: {$missing}");
         }
 
-        // Scan vendor directories for translation files
-        $packageCount = 0;
-        foreach ($vendorPaths as $vendorPath) {
-            $fullPath = base_path($vendorPath);
-
-            if (!is_dir($fullPath)) {
-                $this->warn("Vendor path not found: {$vendorPath}");
-                continue;
-            }
-
-            $packages = glob($fullPath . '/*', GLOB_ONLYDIR);
-
-            foreach ($packages as $package) {
-                $packageName = basename(dirname($package)) . '/' . basename($package);
-
-                foreach ($locales as $locale) {
-                    $translationFile = $package . '/resources/lang/' . $locale . '.json';
-
-                    if (file_exists($translationFile)) {
-                        $translations = json_decode(file_get_contents($translationFile), true);
-
-                        if ($translations && is_array($translations)) {
-                            $count = count($translations);
-                            $this->line("  Found {$count} {$locale} translations in {$packageName}");
-                            $mergedTranslations[$locale] = array_merge($mergedTranslations[$locale], $translations);
-                            $packageCount++;
-                        }
-                    }
-                }
-            }
+        foreach ($report['discoveries'] as $d) {
+            $label = $d['source'] === 'json' ? 'JSON' : 'PHP-array';
+            $this->line("  Found {$d['count']} {$d['locale']} {$label} translations in {$d['package']}");
         }
 
-        if ($packageCount === 0) {
+        if ($report['packageCount'] === 0) {
             $this->warn("No vendor translations found.");
             return;
         }
 
-        // Load existing project translations
-        foreach ($locales as $locale) {
-            $projectFile = resource_path("lang/{$locale}.json");
-            $projectTranslations = [];
-
-            if (file_exists($projectFile)) {
-                $projectTranslations = json_decode(file_get_contents($projectFile), true) ?: [];
-            }
-
-            // Merge: project translations take priority over vendor
-            $finalTranslations = array_merge($mergedTranslations[$locale], $projectTranslations);
-
-            // Sort alphabetically
-            ksort($finalTranslations);
-
-            // Save back to project
-            file_put_contents(
-                $projectFile,
-                json_encode($finalTranslations, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . "\n"
-            );
-
-            $newCount = count($finalTranslations) - count($projectTranslations);
-            $this->info("✓ Merged {$locale}.json - Added {$newCount} new translations, total: " . count($finalTranslations));
+        foreach ($report['merges'] as $locale => $stats) {
+            $this->info("✓ Merged {$locale}.json - Added {$stats['added']} new translations, total: {$stats['total']}");
         }
 
         $this->info("\n✨ Vendor translations merged successfully!");

--- a/src/Command/MissingTranslationAnalyzerCommand.php
+++ b/src/Command/MissingTranslationAnalyzerCommand.php
@@ -15,6 +15,14 @@ class MissingTranslationAnalyzerCommand extends Command
      */
     private $keyFileMap = [];
 
+    /**
+     * Prefixes detected from dynamic translation calls.
+     * Any JSON key starting with one of these is assumed to be used dynamically.
+     *
+     * @var array<string, true>
+     */
+    private $dynamicPrefixes = [];
+
     /** @var TranslationKeyFilter|null */
     private $keyFilter;
 
@@ -28,7 +36,14 @@ class MissingTranslationAnalyzerCommand extends Command
                         {--show-excluded : Show current excluded keys}
                         {--reset-excluded : Reset excluded keys to default}
                         {--json : Output missing translations as JSON with file locations}
-                        {--merge-vendor : Merge translations from vendor packages (condoedge/*, kompo/*) into project}';
+                        {--merge-vendor : Merge translations from vendor packages (condoedge/*, kompo/*) into project}
+                        {--include-plain-text : Include plain-text keys (letters+spaces only) — more coverage, more false positives}
+                        {--locale=* : Locales to check (default: config app.supported_locales or [en, fr])}
+                        {--check-empty-values : List keys with empty or self-referencing values in *.json files}
+                        {--check-obsolete : List keys present in JSON files but never used in code}
+                        {--diff-locales : Show keys present in one locale but missing in others}
+                        {--universal-detection : Capture any quoted string that LOOKS like a translation key — scoped to UI files only (Kompo/Blade/Vue/Enums with label). Higher coverage, more false positives.}
+                        {--include-triaged : Include keys already marked fixed or ignored in the DB (by default, triaged rows are hidden from the report).}';
 
     /**
      * The console command description.
@@ -38,18 +53,37 @@ class MissingTranslationAnalyzerCommand extends Command
     protected $description = 'Analyze and find missing translation keys in the application';
 
     /**
-     * Translation function patterns to match
+     * Single source of truth: every callable that takes a translation key as first argument.
+     *
+     * Each entry describes ONE function; regexes for literal capture, named-arg capture,
+     * and dynamic-prefix extraction are all derived from this list.
+     *
+     *   'regex'       → regex fragment matching the callable name (with escaping done)
+     *   'named_arg'   → supports PHP 8 named args `func(key: '...')`
+     *   'lookbehind'  → extra negative lookbehind to avoid false opens (e.g. `$t` shouldn't match `foo$t`)
+     *   'multi_arg'   → the key is followed by other args (e.g. `trans_choice('key', $n)`)
      */
-    private const TRANSLATION_PATTERNS = [
-        '__' => '/__\s*\(\s*[\'"]([^\'"]+)[\'"]\s*\)/',
-        'trans' => '/trans\s*\(\s*[\'"]([^\'"]+)[\'"]\s*\)/',
-        '@lang' => '/@lang\s*\(\s*[\'"]([^\'"]+)[\'"]\s*\)/',
-        'trans_choice' => '/trans_choice\s*\(\s*[\'"]([^\'"]+)[\'"]\s*,/',
-        'Lang::get' => '/Lang::get\s*\(\s*[\'"]([^\'"]+)[\'"]\s*\)/',
-        'custom_translator' => '/\$this->translator\s*\(\s*[\'"]([^\'"]+)[\'"]\s*\)/',
-        'custom_helpers' => '/_[a-zA-Z]+\s*\(\s*[\'"]([^\'"]+)[\'"]\s*\)/',
-        'underscore' => '/(?<![a-zA-Z])_\s*\(\s*[\'"]([^\'"]+)[\'"]\s*\)/',
-        'titles' => '/protected\s+\$_Title\s*=\s*[\'"](.+?)[\'"]\s*;/',
+    private const TRANSLATION_FUNCTIONS = [
+        ['regex' => '__',                                                     'named_arg' => true,  'lookbehind' => ''],
+        ['regex' => 'trans',                                                  'named_arg' => true,  'lookbehind' => '(?<![a-zA-Z])'],
+        ['regex' => 'trans_choice',                                           'named_arg' => true,  'lookbehind' => '',              'multi_arg' => true],
+        ['regex' => '@lang',                                                  'named_arg' => false, 'lookbehind' => ''],
+        ['regex' => 'Lang::get',                                              'named_arg' => false, 'lookbehind' => ''],
+        ['regex' => '\$this->translator',                                     'named_arg' => false, 'lookbehind' => ''],
+        ['regex' => '_[A-Z][a-zA-Z]+',                                        'named_arg' => false, 'lookbehind' => '', 'multi_arg' => true],
+        ['regex' => '_',                                                      'named_arg' => false, 'lookbehind' => '(?<![a-zA-Z])'], // gettext-style
+        ['regex' => '\$t',                                                    'named_arg' => false, 'lookbehind' => '(?<![a-zA-Z])'], // Vue
+        ['regex' => 'i18n\.t',                                                'named_arg' => false, 'lookbehind' => '(?<![a-zA-Z])'], // Vue-i18n
+        ['regex' => 'throwValidationError\s*\(\s*[\'"][^\'"]+[\'"]\s*,\s*',   'named_arg' => false, 'lookbehind' => '',               'is_raw_prefix' => true],
+    ];
+
+    /**
+     * Extra literal patterns that aren't function calls (PHP properties, Vue directives, array values, …).
+     */
+    private const EXTRA_LITERAL_PATTERNS = [
+        'titles'             => '/protected\s+\$_Title\s*=\s*[\'"](.+?)[\'"]\s*;/u',
+        'vue_directive_t'    => '/v-t\s*=\s*[\'"]([^\'"]+)[\'"]/u',
+        'array_value'        => '/=>\s*[\'"]([a-z][a-z0-9_-]*\.[a-z][a-z0-9._-]*)[\'"]/iu',
     ];
 
     /**
@@ -108,6 +142,22 @@ class MissingTranslationAnalyzerCommand extends Command
             return;
         }
 
+        if ($this->option('check-empty-values')) {
+            $this->checkEmptyValues();
+            return;
+        }
+
+        if ($this->option('check-obsolete')) {
+            $keys = $this->extractAllTranslationKeys();
+            $this->checkObsoleteKeys($keys);
+            return;
+        }
+
+        if ($this->option('diff-locales')) {
+            $this->diffLocales();
+            return;
+        }
+
         $keys = $this->extractAllTranslationKeys();
         $this->indexKeys($keys);
         $this->checkMissingTranslations($keys);
@@ -115,15 +165,20 @@ class MissingTranslationAnalyzerCommand extends Command
     
     private function extractAllTranslationKeys()
     {
+        $linkedPackages = $this->loadLinkedPackages();
 
         $finder = new Finder();
-        $files = $finder->files()
+        $finder->files()
             ->in(base_path())
             ->name('*.php')
             ->name('*.blade.php')
+            ->name('*.vue')
+            ->name('*.js')
+            ->name('*.ts')
             ->exclude('node_modules')
             ->exclude('storage')
             ->exclude('bootstrap/cache')
+            ->exclude('public')
             ->notName('*.lock')
             ->notName('*.min.js')
             ->notName('*.min.css')
@@ -135,24 +190,41 @@ class MissingTranslationAnalyzerCommand extends Command
             ->notPath('*/_ide_helper*')
             ->notPath('*/config/cache/*')
             ->notPath('*/lang/*')
-            ->notPath('*/resources/lang/*')
-            ->filter(function (\SplFileInfo $file) {
-                $path = $file->getRealPath();
-                
-                // If file is not in vendor, include it
-                if (strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR) === false) {
+            ->notPath('*/resources/lang/*');
+
+        // Add any user-linked local packages (folders outside base_path()) as additional roots.
+        foreach ($linkedPackages as $path) {
+            if (is_dir($path)) {
+                $finder->in($path);
+            }
+        }
+
+        $linkedRealPaths = array_filter(array_map('realpath', $linkedPackages));
+
+        $files = $finder->filter(function (\SplFileInfo $file) use ($linkedRealPaths) {
+            $path = $file->getRealPath();
+
+            // Files inside a user-linked package are always included.
+            foreach ($linkedRealPaths as $linked) {
+                if ($linked && strpos($path, $linked . DIRECTORY_SEPARATOR) === 0) {
                     return true;
                 }
-                
-                // If file is in vendor/condoedge or vendor/kompo, include it
-                if (strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'condoedge' . DIRECTORY_SEPARATOR) !== false ||
-                    strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'kompo' . DIRECTORY_SEPARATOR) !== false) {
-                    return true;
-                }
-                
-                // Exclude all other vendor files
-                return false;
-            });
+            }
+
+            // If file is not in vendor, include it
+            if (strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR) === false) {
+                return true;
+            }
+
+            // If file is in vendor/condoedge or vendor/kompo, include it
+            if (strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'condoedge' . DIRECTORY_SEPARATOR) !== false ||
+                strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'kompo' . DIRECTORY_SEPARATOR) !== false) {
+                return true;
+            }
+
+            // Exclude all other vendor files
+            return false;
+        });
 
         $keys = [];
         $this->keyFileMap = []; // Store key to file mappings
@@ -164,6 +236,7 @@ class MissingTranslationAnalyzerCommand extends Command
             }
 
             $content = file_get_contents($file->getRealPath());
+            $this->collectDynamicPrefixes($content);
             $fileKeys = $this->extractKeysFromContent($content, $file->getRealPath());
 
             foreach ($fileKeys as $keyData) {
@@ -201,11 +274,33 @@ class MissingTranslationAnalyzerCommand extends Command
 
     private function checkMissingTranslations($keys)
     {
-        $locales = ['en', 'fr']; // Configure your languages
+        $locales = $this->resolveLocales();
         $missing = [];
 
         if (!$this->option('json')) {
             $this->info("Total translation keys found: " . count($keys));
+        }
+
+        // Pre-fetch rows that were explicitly ignored or fixed — we skip them in the report
+        // so the GUI/CLI never re-propose keys the user has already triaged.
+        $skipGlobal = [];     // key → true (when triaged with no specific locale)
+        $skipPerLocale = [];  // key → [locale => true]
+
+        if (!$this->option('include-triaged')) {
+            $triagedRows = \Condoedge\Utils\Models\MissingTranslation::query()
+                ->whereIn('translation_key', $keys)
+                ->where(function ($q) {
+                    $q->whereNotNull('ignored_at')->orWhereNotNull('fixed_at');
+                })
+                ->get(['translation_key', 'locale', 'ignored_at', 'fixed_at']);
+
+            foreach ($triagedRows as $row) {
+                if (empty($row->locale)) {
+                    $skipGlobal[$row->translation_key] = true;
+                } else {
+                    $skipPerLocale[$row->translation_key][$row->locale] = true;
+                }
+            }
         }
 
         foreach ($locales as $locale) {
@@ -214,9 +309,12 @@ class MissingTranslationAnalyzerCommand extends Command
             }
 
             foreach ($keys as $key) {
+                if (isset($skipGlobal[$key]) || isset($skipPerLocale[$key][$locale])) {
+                    continue;
+                }
                 if (!$this->hasTranslation($key, $locale)) {
                     $locations = $this->keyFileMap[$key] ?? [];
-                    
+
                     $missingData = [
                         'key' => $key,
                         'locations' => $locations
@@ -226,12 +324,18 @@ class MissingTranslationAnalyzerCommand extends Command
                     // Save to MissingTranslation table with file locations
                     try {
                         $firstLocation = !empty($locations) ? $locations[0] : null;
-
                         $filename = $firstLocation['file'] ?? null;
 
-                        $filename = str_contains($filename, 'MissingTranslationAnalyzerCommand') ? null : $filename;
+                        if ($filename && str_contains($filename, 'MissingTranslationAnalyzerCommand')) {
+                            $filename = null;
+                        }
 
-                        \Condoedge\Utils\Models\MissingTranslation::upsertMissingTranslation($key, $firstLocation['file'] ?? null);
+                        \Condoedge\Utils\Models\MissingTranslation::upsertMissingTranslation(
+                            $key,
+                            $filename,
+                            $locale,
+                            $filename
+                        );
                     } catch (\Exception $e) {
                         // Silently continue if database save fails
                     }
@@ -251,15 +355,181 @@ class MissingTranslationAnalyzerCommand extends Command
             }
         }
     }
+    private function resolveLocales(): array
+    {
+        $cli = (array) $this->option('locale');
+        if (!empty($cli)) {
+            return $cli;
+        }
+
+        $configured = config('app.supported_locales');
+        if (is_array($configured) && !empty($configured)) {
+            return $configured;
+        }
+
+        return ['en', 'fr'];
+    }
+
     private function hasTranslation($key, $locale)
     {
-        // Verificar si existe la traducción
         app()->setLocale($locale);
-        
-        // Usar Lang::has() que es más eficiente
-        return \Lang::has($key, $locale);
+
+        if (!\Lang::has($key, $locale)) {
+            return false;
+        }
+
+        // A key can be present with an empty or self-referencing value — still effectively untranslated.
+        $value = \Lang::get($key, [], $locale);
+
+        if (!is_string($value)) {
+            return true;
+        }
+
+        $trimmed = trim($value);
+
+        if ($trimmed === '' || $trimmed === $key) {
+            return false;
+        }
+
+        return true;
     }
    
+    /**
+     * Build all literal-capture regex patterns from the TRANSLATION_FUNCTIONS list + EXTRA_LITERAL_PATTERNS.
+     */
+    private function buildLiteralPatterns(): array
+    {
+        $patterns = [];
+
+        foreach (self::TRANSLATION_FUNCTIONS as $fn) {
+            $head = $fn['lookbehind'] . $fn['regex'];
+            $closing = !empty($fn['multi_arg']) ? '[),]' : '\)';
+
+            if (!empty($fn['is_raw_prefix'])) {
+                // Raw-prefix entries already include the arg list before the key; no opening paren added.
+                $patterns[$fn['regex']] = '/' . $head . '[\'"]([^\'"]+)[\'"]/u';
+                continue;
+            }
+
+            // Standard positional form: func('key'...)
+            $patterns[$fn['regex']] = '/' . $head . '\s*\(\s*[\'"]([^\'"]+)[\'"]\s*' . $closing . '/u';
+
+            if (!empty($fn['named_arg'])) {
+                // Named-arg form: func(key: 'key', ...)
+                $patterns[$fn['regex'] . '__named'] = '/' . $head . '\s*\(\s*key:\s*[\'"]([^\'"]+)[\'"]\s*[,)]/u';
+            }
+        }
+
+        foreach (self::EXTRA_LITERAL_PATTERNS as $name => $pattern) {
+            $patterns[$name] = $pattern;
+        }
+
+        return $patterns;
+    }
+
+    /**
+     * Build all dynamic-prefix extraction regex patterns from the TRANSLATION_FUNCTIONS list.
+     */
+    private function buildDynamicPatterns(): array
+    {
+        $patterns = [];
+
+        foreach (self::TRANSLATION_FUNCTIONS as $fn) {
+            if (!empty($fn['is_raw_prefix'])) {
+                continue; // meaningless for throwValidationError-style (key is 2nd arg, rarely dynamic)
+            }
+
+            $head = $fn['lookbehind'] . $fn['regex'];
+
+            // Interpolation form inside double-quoted: capture static head before $ or {$
+            $patterns[] = '/' . $head . '\s*\(\s*["]([a-zA-Z][a-zA-Z0-9._-]*\.)[^"]*(?:\$|\{\$)/u';
+            // Concatenation form: static head followed by dot-concat with a variable
+            $patterns[] = '/' . $head . '\s*\(\s*[\'"]([a-zA-Z][a-zA-Z0-9._-]*\.)[\'"]\s*\./u';
+        }
+
+        return $patterns;
+    }
+
+    /**
+     * Universal detection: every quoted literal that LOOKS like a translation key.
+     *
+     * Opt-in via --universal-detection. Scoped to UI files only (see isUiFile).
+     * A "translation-looking" key is:
+     *   - at least 2 chars long
+     *   - starts with a letter
+     *   - contains only [a-zA-Z0-9._-]
+     *   - contains at least one '.' OR one '-' (otherwise it's likely a single common word)
+     *
+     * Routes config, class names, database column names are skipped because the scope
+     * excludes routes/, config/, database/ from this pass.
+     */
+    /**
+     * Requires at least one '.' — flat dash keys like "alert-triangle", "arrow-down" are too noisy
+     * (icons, HTML IDs, CSS classes, HTTP headers). Flat keys are already captured by standard
+     * regex when passed to helpers like _Html('accept-invitation').
+     */
+    private const UNIVERSAL_KEY_REGEX = '/[\'"]([a-z][a-zA-Z0-9_-]*\.[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])[\'"]/u';
+
+    /**
+     * Paths that look like UI code (where translation calls are expected).
+     * Used only when --universal-detection is enabled to keep false positives low.
+     */
+    private const UI_PATH_MARKERS = [
+        '/Kompo/',
+        '/Livewire/',
+        '/Filament/',
+        '/Components/',
+        DIRECTORY_SEPARATOR . 'resources' . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR,
+        DIRECTORY_SEPARATOR . 'resources' . DIRECTORY_SEPARATOR . 'js' . DIRECTORY_SEPARATOR,
+    ];
+
+    /**
+     * Paths explicitly excluded from universal detection (non-UI concerns).
+     */
+    private const UNIVERSAL_EXCLUDE_PATHS = [
+        DIRECTORY_SEPARATOR . 'routes' . DIRECTORY_SEPARATOR,
+        DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR,
+        DIRECTORY_SEPARATOR . 'database' . DIRECTORY_SEPARATOR,
+        DIRECTORY_SEPARATOR . 'bootstrap' . DIRECTORY_SEPARATOR,
+        DIRECTORY_SEPARATOR . 'Console' . DIRECTORY_SEPARATOR,
+        DIRECTORY_SEPARATOR . 'Exceptions' . DIRECTORY_SEPARATOR,
+        DIRECTORY_SEPARATOR . 'Middleware' . DIRECTORY_SEPARATOR,
+        DIRECTORY_SEPARATOR . 'Providers' . DIRECTORY_SEPARATOR,
+        DIRECTORY_SEPARATOR . 'Jobs' . DIRECTORY_SEPARATOR,
+        DIRECTORY_SEPARATOR . 'Listeners' . DIRECTORY_SEPARATOR,
+        DIRECTORY_SEPARATOR . 'Observers' . DIRECTORY_SEPARATOR,
+    ];
+
+    private function isUiFile(string $realPath, string $content): bool
+    {
+        $normalized = str_replace('\\', '/', $realPath);
+        $normalizedForExclude = $realPath;
+
+        foreach (self::UNIVERSAL_EXCLUDE_PATHS as $excluded) {
+            if (strpos($normalizedForExclude, $excluded) !== false) {
+                return false;
+            }
+        }
+
+        // Blade and Vue are always UI
+        if (str_ends_with($normalized, '.blade.php') || str_ends_with($normalized, '.vue')) {
+            return true;
+        }
+
+        foreach (self::UI_PATH_MARKERS as $marker) {
+            if (strpos($normalized, str_replace('\\', '/', $marker)) !== false) {
+                return true;
+            }
+        }
+
+        // Enums with label() method often hold UI-facing literals
+        if (preg_match('/enum\s+\w+[^{]*\{[^}]*function\s+label\s*\(/', $content)) {
+            return true;
+        }
+
+        return false;
+    }
+
     private function extractKeysFromContent($content, $filepath = '')
     {
         if ($this->shouldSkipContent($content)) {
@@ -268,8 +538,9 @@ class MissingTranslationAnalyzerCommand extends Command
 
         $keys = [];
         $lines = explode("\n", $content);
+        $patterns = $this->buildLiteralPatterns();
 
-        foreach (self::TRANSLATION_PATTERNS as $name => $pattern) {
+        foreach ($patterns as $name => $pattern) {
             if (preg_match_all($pattern, $content, $matches, PREG_OFFSET_CAPTURE)) {
                 foreach ($matches[1] as $match) {
                     $key = trim($match[0]);
@@ -295,15 +566,43 @@ class MissingTranslationAnalyzerCommand extends Command
             }
         }
 
+        // Optional pass 2 — universal detection, UI-scoped.
+        if ($this->option('universal-detection') && $filepath && $this->isUiFile($filepath, $content)) {
+            if (preg_match_all(self::UNIVERSAL_KEY_REGEX, $content, $matches, PREG_OFFSET_CAPTURE)) {
+                foreach ($matches[1] as $match) {
+                    $key = trim($match[0]);
+                    $offset = $match[1];
+                    $lineNumber = substr_count(substr($content, 0, $offset), "\n") + 1;
+                    $contextStart = max(0, $lineNumber - 3);
+                    $contextEnd = min(count($lines), $lineNumber + 2);
+                    $contextLines = array_slice($lines, $contextStart, $contextEnd - $contextStart);
+                    $context = implode("\n", $contextLines);
+
+                    if ($this->isValidTranslationKey($key, $content, $key)) {
+                        $keys[] = [
+                            'key' => $key,
+                            'line' => $lineNumber,
+                            'context' => $context
+                        ];
+                    }
+                }
+            }
+        }
+
         return $keys;
     }
 
     private function getMatchContext($content, $match)
     {
+        // Narrow window BEFORE the match only: context-based exclusions are meant to catch
+        // the immediate wrapping function call (e.g. `config('some.key')`), not unrelated nearby code.
         $position = strpos($content, $match);
-        $start = max(0, $position - 100);
-        $length = min(200, strlen($content) - $start);
-        
+        if ($position === false) {
+            return '';
+        }
+        $start = max(0, $position - 40);
+        $length = $position - $start;
+
         return substr($content, $start, $length);
     }
 
@@ -317,6 +616,7 @@ class MissingTranslationAnalyzerCommand extends Command
     {
         if (!$this->keyFilter) {
             $this->keyFilter = new TranslationKeyFilter();
+            $this->keyFilter->allowPlainText = (bool) $this->option('include-plain-text');
         }
         return $this->keyFilter;
     }
@@ -452,6 +752,238 @@ class MissingTranslationAnalyzerCommand extends Command
             } else {
                 $this->info("✓ All translations are complete for {$locale}");
             }
+        }
+    }
+
+    /**
+     * Detect dynamic translation calls and extract their literal prefix.
+     *
+     * Examples (backticks used in examples to avoid self-matching on this file):
+     *   `__(<ns>.$var)`    →  extracts the static prefix before the interpolation
+     *   `__(<ns>. . $var)` →  extracts the static prefix before the concatenation
+     *
+     * Pure variable calls like `__(<var>)` are deliberately IGNORED — they have no
+     * static prefix so we can't derive any safe namespace to whitelist; those cases
+     * remain a known blind spot.
+     */
+    private function collectDynamicPrefixes(string $content): void
+    {
+        foreach ($this->buildDynamicPatterns() as $pattern) {
+            if (preg_match_all($pattern, $content, $matches)) {
+                foreach ($matches[1] as $prefix) {
+                    $this->dynamicPrefixes[$prefix] = true;
+                }
+            }
+        }
+    }
+
+    private function hasDynamicPrefix(string $key): bool
+    {
+        foreach (array_keys($this->dynamicPrefixes) as $prefix) {
+            if (str_starts_with($key, $prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Load additional local package paths the user wants scanned for translation keys.
+     * File: storage/app/translator_linked_packages.json (JSON array of absolute paths).
+     */
+    public static function loadLinkedPackages(): array
+    {
+        $path = storage_path('app/translator_linked_packages.json');
+        if (!is_file($path)) {
+            return [];
+        }
+        $decoded = json_decode(file_get_contents($path), true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+        return array_values(array_filter($decoded, fn($p) => is_string($p) && $p !== ''));
+    }
+
+    public static function saveLinkedPackages(array $paths): void
+    {
+        $path = storage_path('app/translator_linked_packages.json');
+        @mkdir(dirname($path), 0755, true);
+        file_put_contents(
+            $path,
+            json_encode(array_values(array_unique($paths)), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n"
+        );
+    }
+
+    private function loadLocaleJson(string $locale): array
+    {
+        $path = resource_path("lang/{$locale}.json");
+        if (!file_exists($path)) {
+            return [];
+        }
+        return json_decode(file_get_contents($path), true) ?: [];
+    }
+
+    private function checkEmptyValues(): void
+    {
+        $locales = $this->resolveLocales();
+        $report = [];
+
+        foreach ($locales as $locale) {
+            $data = $this->loadLocaleJson($locale);
+            $empty = [];
+            $selfRef = [];
+
+            foreach ($data as $key => $value) {
+                if (!is_string($value)) continue;
+                $trimmed = trim($value);
+                if ($trimmed === '') {
+                    $empty[] = $key;
+                } elseif ($trimmed === $key) {
+                    $selfRef[] = $key;
+                }
+            }
+
+            $report[$locale] = ['empty' => $empty, 'self_ref' => $selfRef];
+        }
+
+        if ($this->option('json')) {
+            echo json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+            return;
+        }
+
+        foreach ($report as $locale => $buckets) {
+            $this->info("Locale [{$locale}]:");
+            $this->line('  Empty values: ' . count($buckets['empty']));
+            foreach ($buckets['empty'] as $k) $this->line("    - {$k}");
+            $this->line('  Self-referencing (value === key): ' . count($buckets['self_ref']));
+            foreach ($buckets['self_ref'] as $k) $this->line("    - {$k}");
+            $this->line('');
+        }
+    }
+
+    private function checkObsoleteKeys(array $usedKeys): void
+    {
+        $locales = $this->resolveLocales();
+        $usedSet = array_flip($usedKeys);
+        $report = [];
+
+        // Build candidate lists per locale.
+        $candidatesPerLocale = [];
+        $allCandidates = [];
+        $skippedByDynamicPrefix = 0;
+        foreach ($locales as $locale) {
+            $data = $this->loadLocaleJson($locale);
+            $candidates = [];
+            foreach (array_keys($data) as $key) {
+                if (isset($usedSet[$key])) {
+                    continue;
+                }
+                if ($this->hasDynamicPrefix($key)) {
+                    $skippedByDynamicPrefix++;
+                    continue;
+                }
+                $candidates[] = $key;
+                $allCandidates[$key] = true;
+            }
+            $candidatesPerLocale[$locale] = $candidates;
+        }
+
+        // Second pass: literal-string grep across code. A key is "really obsolete"
+        // only if nowhere in the codebase it appears as a quoted string.
+        $reallyObsolete = $this->filterByLiteralGrep(array_keys($allCandidates));
+
+        foreach ($candidatesPerLocale as $locale => $candidates) {
+            $report[$locale] = array_values(array_intersect($candidates, $reallyObsolete));
+        }
+
+        if ($this->option('json')) {
+            echo json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+            return;
+        }
+
+        $rescued = count($allCandidates) - count($reallyObsolete);
+        $prefixes = array_keys($this->dynamicPrefixes);
+        sort($prefixes);
+        $this->info("Dynamic prefixes detected (" . count($prefixes) . "): " . implode(', ', $prefixes));
+        $this->info("Skipped {$skippedByDynamicPrefix} candidate keys matching dynamic prefixes.");
+        $this->info("Literal-grep pass rescued {$rescued} more keys (found as quoted strings elsewhere in code).");
+        $this->line('');
+
+        foreach ($report as $locale => $keys) {
+            $this->warn("Locale [{$locale}] — " . count($keys) . ' obsolete keys (present in JSON, never used in code):');
+            foreach ($keys as $k) $this->line("  - {$k}");
+            $this->line('');
+        }
+    }
+
+    private function filterByLiteralGrep(array $candidates): array
+    {
+        if (empty($candidates)) {
+            return [];
+        }
+
+        // Read every scanned file ONCE into memory, then check each candidate via str_contains.
+        $finder = new Finder();
+        $files = $finder->files()
+            ->in(base_path())
+            ->name('*.php')->name('*.blade.php')->name('*.vue')->name('*.js')->name('*.ts')
+            ->exclude('node_modules')->exclude('storage')->exclude('bootstrap/cache')->exclude('public')
+            ->notName('*.lock')->notName('*.min.js')->notName('*.min.css')
+            ->notPath('*/lang/*')->notPath('*/resources/lang/*')
+            ->filter(function (\SplFileInfo $file) {
+                $path = $file->getRealPath();
+                if (strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR) === false) return true;
+                if (strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'condoedge' . DIRECTORY_SEPARATOR) !== false) return true;
+                if (strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'kompo' . DIRECTORY_SEPARATOR) !== false) return true;
+                return false;
+            });
+
+        $haystack = '';
+        foreach ($files as $file) {
+            $haystack .= file_get_contents($file->getRealPath()) . "\n";
+        }
+
+        $reallyObsolete = [];
+        foreach ($candidates as $key) {
+            // Look for the key wrapped in single OR double quotes (literal string usage).
+            if (
+                strpos($haystack, "'" . $key . "'") === false
+                && strpos($haystack, '"' . $key . '"') === false
+            ) {
+                $reallyObsolete[] = $key;
+            }
+        }
+
+        return $reallyObsolete;
+    }
+
+    private function diffLocales(): void
+    {
+        $locales = $this->resolveLocales();
+        $data = [];
+
+        foreach ($locales as $locale) {
+            $data[$locale] = array_keys($this->loadLocaleJson($locale));
+        }
+
+        $report = [];
+        foreach ($locales as $locale) {
+            $others = array_diff($locales, [$locale]);
+            foreach ($others as $other) {
+                $diffKey = "{$locale}_not_in_{$other}";
+                $report[$diffKey] = array_values(array_diff($data[$locale], $data[$other]));
+            }
+        }
+
+        if ($this->option('json')) {
+            echo json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+            return;
+        }
+
+        foreach ($report as $bucket => $keys) {
+            $this->warn(str_replace('_', ' ', $bucket) . ' (' . count($keys) . '):');
+            foreach ($keys as $k) $this->line("  - {$k}");
+            $this->line('');
         }
     }
 

--- a/src/Command/OpenTranslatorCommand.php
+++ b/src/Command/OpenTranslatorCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Condoedge\Utils\Command;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Process;
+
+class OpenTranslatorCommand extends Command
+{
+    protected $signature = 'app:translator
+                            {json? : Optional path to an existing analyzer JSON export (skips a fresh scan)}
+                            {--python= : Python executable to use. Defaults to "pythonw" on Windows (GUI, no console) and "python3" on Unix.}
+                            {--foreground : Run the GUI in the foreground (block artisan until closed). Useful for debugging.}';
+
+    protected $description = 'Open the SISC Translation Helper desktop GUI (Python/Tkinter).';
+
+    public function handle(): int
+    {
+        $script = realpath(__DIR__ . '/../../tools/translator/translator.py');
+        if (!$script || !is_file($script)) {
+            $this->error('Translator script not found at ' . $script);
+            return Command::FAILURE;
+        }
+
+        $isWindows = PHP_OS_FAMILY === 'Windows';
+        $python = (string) ($this->option('python') ?: ($isWindows ? 'pythonw' : 'python3'));
+        $jsonArg = (string) ($this->argument('json') ?? '');
+
+        $cmd = [$python, $script];
+        if ($jsonArg !== '') {
+            $cmd[] = $jsonArg;
+        }
+
+        $this->info('Launching translator GUI …');
+        $this->line('  ' . implode(' ', array_map('escapeshellarg', $cmd)));
+
+        if ($this->option('foreground')) {
+            // Foreground: pipe stdout/stderr so the user can see errors.
+            $process = new Process($cmd, base_path());
+            $process->setTimeout(null);
+            $process->run(function ($type, $buffer) {
+                $this->getOutput()->write($buffer);
+            });
+            return $process->isSuccessful() ? Command::SUCCESS : Command::FAILURE;
+        }
+
+        // Background (default): fully detach so the GUI survives artisan's exit.
+        $this->spawnDetached($cmd, $isWindows);
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Launch the process fully detached from the current PHP invocation.
+     *
+     * Symfony\Process::start() kills the child on PHP shutdown, which on Windows
+     * makes the Tkinter window disappear immediately. We use platform-native
+     * detachment instead.
+     */
+    private function spawnDetached(array $cmd, bool $isWindows): void
+    {
+        if ($isWindows) {
+            // `start "" /B "<python>" "<script>" [arg]` — no new console, fully detaches.
+            $quoted = array_map(
+                fn($arg) => '"' . str_replace('"', '""', $arg) . '"',
+                $cmd
+            );
+            $full = 'start "" /B ' . implode(' ', $quoted);
+            pclose(popen($full, 'r'));
+            return;
+        }
+
+        // Unix: nohup + background via shell_exec.
+        $quoted = implode(' ', array_map('escapeshellarg', $cmd));
+        shell_exec("nohup {$quoted} > /dev/null 2>&1 &");
+    }
+}

--- a/src/Command/SendEmailForMissingTranslationsCommand.php
+++ b/src/Command/SendEmailForMissingTranslationsCommand.php
@@ -2,58 +2,49 @@
 
 namespace Condoedge\Utils\Command;
 
+use Condoedge\Utils\Services\Translation\MissingTranslationRecord;
+use Condoedge\Utils\Services\Translation\MissingTranslationsStore;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Mail;
-use Symfony\Component\Finder\Finder;
 
 class SendEmailForMissingTranslationsCommand extends Command
 {
-
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
     protected $signature = 'app:send-missing-translations-email';
 
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
     protected $description = 'Sends an email report of missing translations to the configured translator email address.';
 
-
-    /**
-     * Execute the console command.
-     */
-    public function handle()
+    public function __construct(private readonly MissingTranslationsStore $store)
     {
-        $missingTranslations = \Condoedge\Utils\Models\MissingTranslation::unresolved()->get();
+        parent::__construct();
+    }
 
-        if ($missingTranslations->isEmpty()) {
+    public function handle(): int
+    {
+        $unresolved = $this->store->unresolved();
+
+        if ($unresolved->isEmpty()) {
             $this->info('No missing translations found.');
-            return 0;
+            return Command::SUCCESS;
         }
 
         $message = "Missing Translations Report\n\n";
-        $message .= "Total: " . $missingTranslations->count() . " missing translation(s)\n\n";
-        
-        foreach ($missingTranslations as $translation) {
-            $message .= "- {$translation->translation_key}\n";
-            if ($translation->created_at) {
-                $message .= "  Seen in file: {$translation->package}\n";
+        $message .= "Total: " . $unresolved->count() . " missing translation(s)\n\n";
+
+        foreach ($unresolved as $row) {
+            /** @var MissingTranslationRecord $row */
+            $message .= "- {$row->translation_key}\n";
+            if ($row->package) {
+                $message .= "  Seen in file: {$row->package}\n";
             }
             $message .= "\n";
         }
 
-        Mail::raw($message, function ($mail) use ($missingTranslations) {
+        Mail::raw($message, function ($mail) use ($unresolved) {
             $mail->to(config('kompo-utils.translator-email'))
-                ->subject('Missing Translations Report - ' . $missingTranslations->count() . ' keys');
+                ->subject('Missing Translations Report - ' . $unresolved->count() . ' keys');
         });
 
         $this->info('Email sent to ' . config('kompo-utils.translator-email'));
-        
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/CondoedgeUtilsServiceProvider.php
+++ b/src/CondoedgeUtilsServiceProvider.php
@@ -20,20 +20,25 @@ use Condoedge\Utils\Kompo\Plugins\EnableResponsiveTable;
 use Condoedge\Utils\Kompo\Plugins\EnableWhiteTableStyle;
 use Condoedge\Utils\Kompo\Plugins\TableIntoFormSetValuesPlugin;
 use Condoedge\Utils\Services\GlobalConfig\GlobalConfigServiceContract;
-
 use App\Models\User;
 use Condoedge\Utils\Command\FixIncompleteAddressesCommand;
 use Condoedge\Utils\Command\RunComplianceValidationCommand;
 use Condoedge\Utils\Events\MultipleComplianceIssuesDetected;
 use Condoedge\Utils\Kompo\Plugins\DebugReload;
-use Condoedge\Utils\Kompo\Plugins\HasIntroAnimation;
 use Condoedge\Utils\Listeners\HandleBatchComplianceNotifications;
 use Condoedge\Utils\Services\ComplianceValidation\NotificationStrategyRegistry;
 use Condoedge\Utils\Services\Maps\GeocodioService;
 use Condoedge\Utils\Services\Maps\GoogleMapsService;
 use Condoedge\Utils\Services\Maps\NominatimService;
 use Illuminate\Support\Facades\Event;
+use Condoedge\Utils\Command\ClearLazyComponentsCommand;
 use Condoedge\Utils\Command\MissingTranslationAnalyzerCommand;
+use Condoedge\Utils\Command\MarkMissingTranslationCommand;
+use Condoedge\Utils\Command\OpenTranslatorCommand;
+use Condoedge\Utils\Command\LinkedPackagesCommand;
+use Condoedge\Utils\Kompo\Common\Grid;
+use Condoedge\Utils\Kompo\Plugins\HasTutorial;
+use Condoedge\Utils\Kompo\Plugins\LazyComponentPlugin;
 
 class CondoedgeUtilsServiceProvider extends ServiceProvider
 {
@@ -62,6 +67,7 @@ class CondoedgeUtilsServiceProvider extends ServiceProvider
             __DIR__ . '/../config/kompo-utils.php' => config_path('kompo-utils.php'),
             __DIR__ . '/../config/kompo-files.php' => config_path('kompo-files.php'),
             __DIR__ . '/../config/kompo-tags.php' => config_path('kompo-tags.php'),
+            __DIR__ . '/../config/analytics.php' => config_path('analytics.php'),
         ], 'kompo-utils-config');
 
         $this->publishes([
@@ -84,8 +90,9 @@ class CondoedgeUtilsServiceProvider extends ServiceProvider
 
         Query::setPlugins([
             ExportPlugin::class,
-            HasIntroAnimation::class,
+            HasTutorial::class,
             EnableWhiteTableStyle::class,
+            LazyComponentPlugin::class,
         ]);
 
         Table::setPlugins([
@@ -93,21 +100,29 @@ class CondoedgeUtilsServiceProvider extends ServiceProvider
             EnableWhiteTableStyle::class,
             EnableResponsiveTable::class,
             TableIntoFormSetValuesPlugin::class,
-            HasIntroAnimation::class,
+            HasTutorial::class,
+            LazyComponentPlugin::class,
         ]);
 
         Form::setPlugins([
             DebugReload::class,
-            HasIntroAnimation::class,
+            HasTutorial::class,
+            LazyComponentPlugin::class,
         ]);
 
         Modal::setPlugins([
             HasScroll::class,
             DebugReload::class,
-            HasIntroAnimation::class,
+            HasTutorial::class,
+            LazyComponentPlugin::class,
+        ]);
+
+        Grid::setPlugins([
+            LazyComponentPlugin::class,
         ]);
 
         $this->registerComplianceNotificationSystem();
+        $this->registerAnalyticsListeners();
     }
 
     /**
@@ -155,7 +170,7 @@ class CondoedgeUtilsServiceProvider extends ServiceProvider
 
             $driverClass = $driverConfig['class'];
 
-            return new $driverClass();
+            return app()->make($driverClass);
         });
 
         $this->app->bind('note-model', function () {
@@ -188,6 +203,10 @@ class CondoedgeUtilsServiceProvider extends ServiceProvider
 
         $this->app->bind(\Condoedge\Utils\Services\Maps\GeocodingService::class, function ($app) {
             return $app->make(NominatimService::class);
+        });
+
+        $this->app->singleton(\Condoedge\Utils\Services\Analytics\GoogleAnalyticsService::class, function ($app) {
+            return new \Condoedge\Utils\Services\Analytics\GoogleAnalyticsService();
         });
 
         // Register compliance notification system
@@ -225,6 +244,7 @@ class CondoedgeUtilsServiceProvider extends ServiceProvider
             'kompo-utils' => __DIR__.'/../config/kompo-utils.php',
             'kompo-tags' => __DIR__.'/../config/kompo-tags.php',
             'errors-views' => __DIR__.'/../config/errors-views.php',
+            'analytics' => __DIR__.'/../config/analytics.php',
         ];
 
         foreach ($dirs as $key => $path) {
@@ -249,7 +269,11 @@ class CondoedgeUtilsServiceProvider extends ServiceProvider
                 RunComplianceValidationCommand::class,
                 FixIncompleteAddressesCommand::class,
                 MissingTranslationAnalyzerCommand::class,
+                MarkMissingTranslationCommand::class,
+                OpenTranslatorCommand::class,
+                LinkedPackagesCommand::class,
                 SendEmailForMissingTranslationsCommand::class,
+                ClearLazyComponentsCommand::class,
             ]);
         }
     }
@@ -274,6 +298,21 @@ class CondoedgeUtilsServiceProvider extends ServiceProvider
             // Option 3: Hourly checks (good compromise)
             $schedule->command('compliance:run-validation --scheduled')->hourly();
         });
+    }
+
+    /**
+     * Register Google Analytics event listeners
+     */
+    protected function registerAnalyticsListeners(): void
+    {
+        if (!config('services.google_analytics.measurement_id')) {
+            return;
+        }
+
+        Event::listen(\Illuminate\Auth\Events\Login::class,
+            \Condoedge\Utils\Listeners\TrackUserLogin::class);
+        Event::listen(\Illuminate\Auth\Events\Logout::class,
+            \Condoedge\Utils\Listeners\TrackUserLogout::class);
     }
 
     /**

--- a/src/CondoedgeUtilsServiceProvider.php
+++ b/src/CondoedgeUtilsServiceProvider.php
@@ -154,6 +154,21 @@ class CondoedgeUtilsServiceProvider extends ServiceProvider
             return new PluginsManager();
         });
 
+        // Translation analyzer services — singletons so each run of the analyzer
+        // command reuses the same scanner / detector instances across helper calls.
+        $this->app->singleton(\Condoedge\Utils\Services\Translation\PhpArrayLangReader::class);
+        $this->app->singleton(\Condoedge\Utils\Services\Translation\TranslationKeyFilter::class);
+        $this->app->singleton(\Condoedge\Utils\Services\Translation\ExcludedKeysRepository::class);
+        $this->app->singleton(\Condoedge\Utils\Services\Translation\LocaleFilesRepository::class);
+        $this->app->singleton(\Condoedge\Utils\Services\Translation\KeyCodeScanner::class);
+        $this->app->singleton(\Condoedge\Utils\Services\Translation\ObsoleteKeyDetector::class);
+        $this->app->singleton(\Condoedge\Utils\Services\Translation\VendorTranslationMerger::class);
+        $this->app->singleton(\Condoedge\Utils\Services\Translation\MissingTranslationsStore::class);
+        $this->app->singleton(
+            \Condoedge\Utils\Services\Translation\MissingTranslationCheckerInterface::class,
+            \Condoedge\Utils\Services\Translation\MissingTranslationChecker::class,
+        );
+
         // Register services for integrity checking
         $this->app->bind('finance.graph', function ($app) {
             return new Graph();

--- a/src/Kompo/Translations/MissingTranslationsTable.php
+++ b/src/Kompo/Translations/MissingTranslationsTable.php
@@ -26,7 +26,10 @@ class MissingTranslationsTable extends WhiteTable
     {
         return [
             _Th('utils.translation-key'),
+            _Th('utils.locale')->class('w-12'),
+            _Th('utils.hits')->class('w-12 text-right'),
             _Th('utils.package'),
+            _Th('utils.file'),
             _Th('utils.ignore')->class('text-right w-6'),
             _Th('utils.fixed')->class('text-right w-6'),
         ];
@@ -37,7 +40,13 @@ class MissingTranslationsTable extends WhiteTable
         return _TableRow(
             _Html($missingTranslation->translation_key),
 
-            _Html(substr($missingTranslation->package, -75) ?? '-'),
+            _Html($missingTranslation->locale ?: '-'),
+
+            _Html((string) ($missingTranslation->hit_count ?? 0))->class('text-right'),
+
+            _Html(substr($missingTranslation->package ?? '', -75) ?: '-'),
+
+            $this->fileLink($missingTranslation->file_path),
 
             _Checkbox()->name('ignored_at')->value($missingTranslation->ignored_at ? 1 : 0)
                 ->class('!mb-0 mx-auto')
@@ -47,6 +56,20 @@ class MissingTranslationsTable extends WhiteTable
                 ->class('!mb-0 mx-auto')
                 ->selfPost('markAsFixed', ['id' => $missingTranslation->id])->browse(),
         );
+    }
+
+    protected function fileLink(?string $filePath)
+    {
+        if (!$filePath) {
+            return _Html('-');
+        }
+
+        $scheme = config('kompo-utils.editor-scheme', 'vscode');
+        $absolute = base_path($filePath);
+        $href = $scheme . '://file/' . str_replace('\\', '/', $absolute);
+        $short = strlen($filePath) > 60 ? '…' . substr($filePath, -60) : $filePath;
+
+        return _Link($short)->href($href)->inNewTab()->class('text-info underline');
     }
 
     public function markAsIgnored($id)

--- a/src/Kompo/Translations/MissingTranslationsTable.php
+++ b/src/Kompo/Translations/MissingTranslationsTable.php
@@ -3,13 +3,21 @@
 namespace Condoedge\Utils\Kompo\Translations;
 
 use Condoedge\Utils\Kompo\Common\WhiteTable;
-use Condoedge\Utils\Models\MissingTranslation;
+use Condoedge\Utils\Services\Translation\MissingTranslationRecord;
+use Condoedge\Utils\Services\Translation\MissingTranslationsStore;
 
 class MissingTranslationsTable extends WhiteTable
 {
+    protected MissingTranslationsStore $store;
+
+    public function created()
+    {
+        $this->store = app(MissingTranslationsStore::class);
+    }
+
     public function query()
     {
-        return MissingTranslation::query()
+        return $this->store->query()
             ->when(!request('include_ignored_ones'), fn($q) => $q->whereNull('ignored_at'))
             ->whereNull('fixed_at');
     }
@@ -35,26 +43,23 @@ class MissingTranslationsTable extends WhiteTable
         ];
     }
 
-    public function render($missingTranslation)
+    public function render($row)
     {
+        /** @var MissingTranslationRecord $row */
         return _TableRow(
-            _Html($missingTranslation->translation_key),
+            _Html($row->translation_key),
+            _Html($row->locale ?: '-'),
+            _Html((string) $row->hit_count)->class('text-right'),
+            _Html(substr($row->package ?? '', -75) ?: '-'),
+            $this->fileLink($row->file_path),
 
-            _Html($missingTranslation->locale ?: '-'),
-
-            _Html((string) ($missingTranslation->hit_count ?? 0))->class('text-right'),
-
-            _Html(substr($missingTranslation->package ?? '', -75) ?: '-'),
-
-            $this->fileLink($missingTranslation->file_path),
-
-            _Checkbox()->name('ignored_at')->value($missingTranslation->ignored_at ? 1 : 0)
+            _Checkbox()->name('ignored_at')->value($row->ignored_at ? 1 : 0)
                 ->class('!mb-0 mx-auto')
-                ->selfPost('markAsIgnored', ['id' => $missingTranslation->id])->browse(),
+                ->selfPost('markAsIgnored', ['id' => $row->id])->browse(),
 
-            _Checkbox()->name('fixed_at')->value($missingTranslation->fixed_at ? 1 : 0)
+            _Checkbox()->name('fixed_at')->value($row->fixed_at ? 1 : 0)
                 ->class('!mb-0 mx-auto')
-                ->selfPost('markAsFixed', ['id' => $missingTranslation->id])->browse(),
+                ->selfPost('markAsFixed', ['id' => $row->id])->browse(),
         );
     }
 
@@ -64,25 +69,21 @@ class MissingTranslationsTable extends WhiteTable
             return _Html('-');
         }
 
-        $scheme = config('kompo-utils.editor-scheme', 'vscode');
+        $scheme   = config('kompo-utils.editor-scheme', 'vscode');
         $absolute = base_path($filePath);
-        $href = $scheme . '://file/' . str_replace('\\', '/', $absolute);
-        $short = strlen($filePath) > 60 ? '…' . substr($filePath, -60) : $filePath;
+        $href     = $scheme . '://file/' . str_replace('\\', '/', $absolute);
+        $short    = strlen($filePath) > 60 ? '…' . substr($filePath, -60) : $filePath;
 
         return _Link($short)->href($href)->inNewTab()->class('text-info underline');
     }
 
     public function markAsIgnored($id)
     {
-        $missingTranslation = MissingTranslation::findOrFail($id);
-        $missingTranslation->ignored_at = now();
-        $missingTranslation->save();
+        $this->store->markIgnored($id);
     }
 
     public function markAsFixed($id)
     {
-        $missingTranslation = MissingTranslation::findOrFail($id);
-        $missingTranslation->fixed_at = now();
-        $missingTranslation->save();
+        $this->store->markFixed($id);
     }
 }

--- a/src/Models/MissingTranslation.php
+++ b/src/Models/MissingTranslation.php
@@ -7,26 +7,76 @@ use Illuminate\Support\Facades\Cache;
 
 class MissingTranslation extends Model
 {
-    public static function upsertMissingTranslation($translationKey, $package = null)
+    protected static function booted()
     {
-        $cacheKey = 'translation_missing_' . $translationKey;
+        parent::booted();
 
-        return Cache::rememberForever($cacheKey, function () use ($translationKey, $package) {
-            if ($translation = static::where('translation_key', $translationKey)->first()) {
-                return $translation;
+        static::saved(function (self $model) {
+            if ($model->wasChanged('fixed_at') || $model->wasChanged('ignored_at')) {
+                $model->clearDetectionCache();
             }
+        });
 
+        static::deleted(function (self $model) {
+            $model->clearDetectionCache();
+        });
+    }
+
+    public function clearDetectionCache(): void
+    {
+        $key = $this->translation_key;
+        if (!$key) {
+            return;
+        }
+
+        // Clear both the per-locale cache entry and the legacy wildcard entry used before locale split.
+        Cache::forget('translation_missing_' . $key . ':' . ($this->locale ?? '*'));
+        Cache::forget('translation_missing_' . $key . ':*');
+        Cache::forget('translation_missing_' . $key);
+    }
+
+    public static function upsertMissingTranslation($translationKey, $package = null, ?string $locale = null, ?string $filePath = null)
+    {
+        $cacheKey = 'translation_missing_' . $translationKey . ':' . ($locale ?? '*');
+
+        if ($cached = Cache::get($cacheKey)) {
+            $cached->increment('hit_count');
+            $cached->last_seen_at = now();
+            $cached->save();
+            return $cached;
+        }
+
+        $translation = static::where('translation_key', $translationKey)
+            ->where(function ($q) use ($locale) {
+                $locale === null ? $q->whereNull('locale') : $q->where('locale', $locale);
+            })
+            ->first();
+
+        if (!$translation) {
             $translation = new static();
             $translation->translation_key = $translationKey;
-            $translation->package = $package;
-            $translation->save();
+            $translation->locale = $locale;
+            $translation->hit_count = 0;
+        }
 
-            return $translation;
-        });
+        $translation->package = $package ?: $translation->package;
+        $translation->file_path = $filePath ?: $translation->file_path;
+        $translation->hit_count = ($translation->hit_count ?? 0) + 1;
+        $translation->last_seen_at = now();
+        $translation->save();
+
+        Cache::put($cacheKey, $translation, now()->addDay());
+
+        return $translation;
     }
 
     public function scopeUnresolved($query)
     {
         return $query->whereNull('fixed_at')->whereNull('ignored_at');
+    }
+
+    public function scopeForLocale($query, ?string $locale)
+    {
+        return $query->where('locale', $locale);
     }
 }

--- a/src/Models/MissingTranslation.php
+++ b/src/Models/MissingTranslation.php
@@ -2,81 +2,97 @@
 
 namespace Condoedge\Utils\Models;
 
-use Condoedge\Utils\Models\Model;
-use Illuminate\Support\Facades\Cache;
+use Condoedge\Utils\Services\Translation\MissingTranslationRecord;
+use Condoedge\Utils\Services\Translation\MissingTranslationsQuery;
+use Condoedge\Utils\Services\Translation\MissingTranslationsStore;
 
-class MissingTranslation extends Model
+/**
+ * Façade over the JSON-backed {@see MissingTranslationsStore}. Kept in the
+ * Models namespace (and with the same class name the rest of the codebase
+ * was using) so existing callers — TrackingTranslator, the CLI commands,
+ * the Kompo table — keep working after the DB was removed.
+ *
+ * This class no longer extends Eloquent's `Model` — there is no database row
+ * behind it. Instances are thin wrappers around a read-only
+ * {@see MissingTranslationRecord} DTO.
+ */
+class MissingTranslation
 {
-    protected static function booted()
-    {
-        parent::booted();
+    public function __construct(public readonly MissingTranslationRecord $record) {}
 
-        static::saved(function (self $model) {
-            if ($model->wasChanged('fixed_at') || $model->wasChanged('ignored_at')) {
-                $model->clearDetectionCache();
-            }
-        });
+    // -------------------------------------------------------------- BC API
 
-        static::deleted(function (self $model) {
-            $model->clearDetectionCache();
-        });
+    /**
+     * Same signature the rest of the codebase was calling before the DB
+     * was replaced. Returns the upserted row (as a façade) so callers that
+     * do `->increment('hit_count')` or read properties keep working.
+     */
+    public static function upsertMissingTranslation(
+        string $translationKey,
+        $package = null,
+        ?string $locale = null,
+        ?string $filePath = null,
+    ): self {
+        $record = static::store()->upsert($translationKey, $locale, $package, $filePath);
+        return new self($record);
     }
 
-    public function clearDetectionCache(): void
+    public static function query(): MissingTranslationsQuery
     {
-        $key = $this->translation_key;
-        if (!$key) {
-            return;
+        return static::store()->query();
+    }
+
+    public static function findOrFail(string $id): self
+    {
+        $record = static::store()->findById($id);
+        if (!$record) {
+            throw new \RuntimeException("Missing translation [{$id}] not found.");
         }
-
-        // Clear both the per-locale cache entry and the legacy wildcard entry used before locale split.
-        Cache::forget('translation_missing_' . $key . ':' . ($this->locale ?? '*'));
-        Cache::forget('translation_missing_' . $key . ':*');
-        Cache::forget('translation_missing_' . $key);
+        return new self($record);
     }
 
-    public static function upsertMissingTranslation($translationKey, $package = null, ?string $locale = null, ?string $filePath = null)
+    public static function unresolved(): MissingTranslationsQuery
     {
-        $cacheKey = 'translation_missing_' . $translationKey . ':' . ($locale ?? '*');
-
-        if ($cached = Cache::get($cacheKey)) {
-            $cached->increment('hit_count');
-            $cached->last_seen_at = now();
-            $cached->save();
-            return $cached;
-        }
-
-        $translation = static::where('translation_key', $translationKey)
-            ->where(function ($q) use ($locale) {
-                $locale === null ? $q->whereNull('locale') : $q->where('locale', $locale);
-            })
-            ->first();
-
-        if (!$translation) {
-            $translation = new static();
-            $translation->translation_key = $translationKey;
-            $translation->locale = $locale;
-            $translation->hit_count = 0;
-        }
-
-        $translation->package = $package ?: $translation->package;
-        $translation->file_path = $filePath ?: $translation->file_path;
-        $translation->hit_count = ($translation->hit_count ?? 0) + 1;
-        $translation->last_seen_at = now();
-        $translation->save();
-
-        Cache::put($cacheKey, $translation, now()->addDay());
-
-        return $translation;
+        return static::store()->query()
+            ->whereNull('fixed_at')
+            ->whereNull('ignored_at');
     }
 
-    public function scopeUnresolved($query)
+    // -------------------------------------------------------------- instance
+
+    /**
+     * Proxy reads to the underlying record so callers can keep using
+     * `$row->translation_key`, `$row->hit_count`, etc.
+     */
+    public function __get(string $name): mixed
     {
-        return $query->whereNull('fixed_at')->whereNull('ignored_at');
+        return $this->record->{$name} ?? null;
     }
 
-    public function scopeForLocale($query, ?string $locale)
+    public function markFixed(): self
     {
-        return $query->where('locale', $locale);
+        return new self(static::store()->markFixed($this->record->id) ?? $this->record);
+    }
+
+    public function markIgnored(): self
+    {
+        return new self(static::store()->markIgnored($this->record->id) ?? $this->record);
+    }
+
+    public function reset(): self
+    {
+        return new self(static::store()->reset($this->record->id) ?? $this->record);
+    }
+
+    public function delete(): bool
+    {
+        return static::store()->delete($this->record->id);
+    }
+
+    // -------------------------------------------------------------- helpers
+
+    private static function store(): MissingTranslationsStore
+    {
+        return app(MissingTranslationsStore::class);
     }
 }

--- a/src/Services/Translation/DynamicPrefixDetector.php
+++ b/src/Services/Translation/DynamicPrefixDetector.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Condoedge\Utils\Services\Translation;
+
+/**
+ * Collects literal namespace prefixes used in DYNAMIC translation calls.
+ *
+ * A dynamic call is any translation helper invocation whose first argument
+ * contains a variable (interpolation or concatenation). The detector extracts
+ * the literal head that precedes the variable — e.g. in a call like
+ * `trans(<ns-dot-variable>)` the head "ns." is remembered so that later,
+ * any translation key starting with "ns." can be considered "used
+ * dynamically" even though no static string match exists for it.
+ *
+ * NOTE: examples are intentionally written with placeholders rather than
+ * actual quoted strings, to avoid this file self-matching its own regexes
+ * when the analyzer scans the vendor directory.
+ *
+ * Usage:
+ *   $d = new DynamicPrefixDetector($translationFunctions);
+ *   foreach ($files as $content) { $d->collect($content); }
+ *   $d->matches('events.foo'); // true if any prefix matches
+ *   $d->prefixes();            // list of detected prefixes for reporting
+ *
+ * The list of translation function regex fragments comes from the command's
+ * TRANSLATION_FUNCTIONS metadata so both literal and dynamic detection stay
+ * in sync (single source of truth).
+ */
+class DynamicPrefixDetector
+{
+    /** @var array<string, true> set of detected prefixes (with trailing dot) */
+    private array $prefixes = [];
+
+    /** @var string[] compiled regex patterns built once */
+    private array $patterns;
+
+    /**
+     * @param array<int, array{regex:string, lookbehind?:string, is_raw_prefix?:bool}> $translationFunctions
+     */
+    public function __construct(array $translationFunctions)
+    {
+        $this->patterns = $this->buildPatterns($translationFunctions);
+    }
+
+    /**
+     * Scan a file's content and remember every static prefix used in dynamic
+     * translation calls.
+     */
+    public function collect(string $content): void
+    {
+        foreach ($this->patterns as $pattern) {
+            if (preg_match_all($pattern, $content, $matches)) {
+                foreach ($matches[1] as $prefix) {
+                    $this->prefixes[$prefix] = true;
+                }
+            }
+        }
+    }
+
+    public function matches(string $key): bool
+    {
+        foreach (array_keys($this->prefixes) as $prefix) {
+            if (str_starts_with($key, $prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return string[] sorted list of detected prefixes
+     */
+    public function prefixes(): array
+    {
+        $list = array_keys($this->prefixes);
+        sort($list);
+        return $list;
+    }
+
+    public function count(): int
+    {
+        return count($this->prefixes);
+    }
+
+    /**
+     * Build one regex per translation function that captures the static head
+     * of a dynamic call (interpolation or concatenation form).
+     *
+     * @param array<int, array{regex:string, lookbehind?:string, is_raw_prefix?:bool}> $functions
+     * @return string[]
+     */
+    private function buildPatterns(array $functions): array
+    {
+        $patterns = [];
+        foreach ($functions as $fn) {
+            if (!empty($fn['is_raw_prefix'])) {
+                continue;
+            }
+            $head = ($fn['lookbehind'] ?? '') . $fn['regex'];
+
+            // Double-quoted interpolation form: static head before $ or {$
+            $patterns[] = '/' . $head . '\s*\(\s*["]([a-zA-Z][a-zA-Z0-9._-]*\.)[^"]*(?:\$|\{\$)/u';
+
+            // Concatenation form: static head followed by dot-concat with a variable
+            $patterns[] = '/' . $head . '\s*\(\s*[\'"]([a-zA-Z][a-zA-Z0-9._-]*\.)[\'"]\s*\./u';
+        }
+        return $patterns;
+    }
+}

--- a/src/Services/Translation/ExcludedKeysRepository.php
+++ b/src/Services/Translation/ExcludedKeysRepository.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Condoedge\Utils\Services\Translation;
+
+/**
+ * Persists the list of translation keys the user explicitly wants the analyzer
+ * to ignore (false positives like icon names, CSS classes, etc.).
+ *
+ * File: storage/app/translation_exclude_keys.json — a JSON array of strings.
+ * Default list seeds the file on first access.
+ */
+class ExcludedKeysRepository
+{
+    /**
+     * Default seeds — common false-positive tokens that are never real
+     * translation keys in a Laravel / Kompo app.
+     */
+    private const DEFAULT_EXCLUDED = [
+        // Framework / Kompo helper names accidentally captured
+        '_CollapsibleSideSection', '_CollapsibleInnerSection', '_CollapsibleSideTitle',
+        '_CollapsibleSideItem', '_Button', '_Link', '_Flex', '_Html', '_Sax', '_Collapsible',
+        // HTML attributes
+        'class', 'id', 'href', 'src', 'alt', 'title', 'name', 'value', 'type',
+        // Technical shorthand
+        'php', 'js', 'css', 'html', 'json', 'xml', 'api', 'admin',
+        // UI states that look like keys but aren't
+        'hidden', 'active', 'disabled', 'loading', 'home', 'login', 'logout',
+    ];
+
+    public function all(): array
+    {
+        $path = $this->path();
+
+        if (is_file($path)) {
+            $decoded = json_decode(file_get_contents($path), true);
+            if (is_array($decoded)) {
+                return array_values(array_unique(array_map('strval', $decoded)));
+            }
+        }
+
+        // First access — seed the file with defaults so the user can edit it later.
+        $this->save(self::DEFAULT_EXCLUDED);
+        return self::DEFAULT_EXCLUDED;
+    }
+
+    public function add(array $keys): int
+    {
+        $current = $this->all();
+        $merged  = array_values(array_unique([...$current, ...array_map('strval', $keys)]));
+        $this->save($merged);
+        return count($merged) - count($current);
+    }
+
+    public function reset(): void
+    {
+        $path = $this->path();
+        if (is_file($path)) {
+            @unlink($path);
+        }
+    }
+
+    public function contains(string $key): bool
+    {
+        return in_array($key, $this->all(), true);
+    }
+
+    public function path(): string
+    {
+        return storage_path('app/translation_exclude_keys.json');
+    }
+
+    private function save(array $keys): void
+    {
+        @mkdir(dirname($this->path()), 0755, true);
+        file_put_contents(
+            $this->path(),
+            json_encode(array_values($keys), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) . "\n"
+        );
+    }
+}

--- a/src/Services/Translation/KeyCodeScanner.php
+++ b/src/Services/Translation/KeyCodeScanner.php
@@ -1,0 +1,360 @@
+<?php
+
+namespace Condoedge\Utils\Services\Translation;
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Scans PHP / Blade / Vue / JS code for translation keys.
+ *
+ * Owns the authoritative `TRANSLATION_FUNCTIONS` metadata — literal capture
+ * patterns, dynamic-prefix patterns (via {@see DynamicPrefixDetector}) and
+ * vendor-scope rules are all derived from it. Sharing the detector across
+ * services keeps literal + dynamic detection in sync.
+ *
+ * Callers can also reuse {@see buildCodeFilesFinder()} to walk the same
+ * scope of files with different logic (e.g. ObsoleteKeyDetector's literal
+ * grep rescue pass).
+ */
+class KeyCodeScanner
+{
+    /**
+     * Every callable that takes a translation key as first argument.
+     * Literal capture, named-arg capture, and dynamic-prefix extraction are
+     * all derived from this list so adding a new helper = 1 entry here.
+     *
+     *   regex          callable name (regex-ready, with escapes)
+     *   named_arg      supports PHP 8 named args `func(key: '...')`
+     *   lookbehind     extra negative lookbehind to avoid false opens
+     *   multi_arg      key followed by other args (e.g. trans_choice)
+     *   is_raw_prefix  pattern already includes the arg list before the key
+     */
+    public const TRANSLATION_FUNCTIONS = [
+        ['regex' => '__',                                                     'named_arg' => true,  'lookbehind' => ''],
+        ['regex' => 'trans',                                                  'named_arg' => true,  'lookbehind' => '(?<![a-zA-Z])'],
+        ['regex' => 'trans_choice',                                           'named_arg' => true,  'lookbehind' => '',              'multi_arg' => true],
+        ['regex' => '@lang',                                                  'named_arg' => false, 'lookbehind' => ''],
+        ['regex' => 'Lang::get',                                              'named_arg' => false, 'lookbehind' => ''],
+        ['regex' => '\$this->translator',                                     'named_arg' => false, 'lookbehind' => ''],
+        ['regex' => '_[A-Z][a-zA-Z]+',                                        'named_arg' => false, 'lookbehind' => '', 'multi_arg' => true],
+        ['regex' => '_',                                                      'named_arg' => false, 'lookbehind' => '(?<![a-zA-Z])'],
+        ['regex' => '\$t',                                                    'named_arg' => false, 'lookbehind' => '(?<![a-zA-Z])'],
+        ['regex' => 'i18n\.t',                                                'named_arg' => false, 'lookbehind' => '(?<![a-zA-Z])'],
+        ['regex' => 'throwValidationError\s*\(\s*[\'"][^\'"]+[\'"]\s*,\s*',   'named_arg' => false, 'lookbehind' => '', 'is_raw_prefix' => true],
+    ];
+
+    /** Patterns that are NOT function calls (PHP properties, Vue directives, array values). */
+    private const EXTRA_LITERAL_PATTERNS = [
+        'titles'          => '/protected\s+\$_Title\s*=\s*[\'"](.+?)[\'"]\s*;/u',
+        'vue_directive_t' => '/v-t\s*=\s*[\'"]([^\'"]+)[\'"]/u',
+        'array_value'     => '/=>\s*[\'"]([a-z][a-z0-9_-]*\.[a-z][a-z0-9._-]*)[\'"]/iu',
+    ];
+
+    /**
+     * When universal-detection is enabled, every quoted literal matching this
+     * shape inside a UI file is considered a candidate key.
+     */
+    private const UNIVERSAL_KEY_REGEX = '/[\'"]([a-z][a-zA-Z0-9_-]*\.[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])[\'"]/u';
+
+    private const UI_PATH_MARKERS = [
+        '/Kompo/',
+        '/Livewire/',
+        '/Filament/',
+        '/Components/',
+    ];
+
+    private const UNIVERSAL_EXCLUDE_PATHS = [
+        'routes', 'config', 'database', 'bootstrap',
+        'Console', 'Exceptions', 'Middleware', 'Providers',
+        'Jobs', 'Listeners', 'Observers',
+    ];
+
+    private const FILE_EXCLUSIONS = [
+        'files' => [
+            'composer.lock', 'package-lock.json', 'yarn.lock', 'webpack.mix.js',
+            'tailwind.config.js', 'vite.config.js', '_ide_helper.php', 'server.php', 'artisan',
+        ],
+        'patterns' => [
+            '/\.min\.(js|css)$/', '/\.lock$/', '/Test\.php$/', '/_test\.php$/',
+            '/Migration\.php$/', '/Seeder\.php$/', '/Factory\.php$/',
+        ],
+        'paths' => [
+            '/vendor/', '/node_modules/', '/storage/', '/bootstrap/cache/',
+            '/public/build/', '/public/hot',
+        ],
+    ];
+
+    private ?DynamicPrefixDetector $dynamicDetector = null;
+
+    /** @var array<string, string>|null  memoized literal-capture patterns */
+    private ?array $literalPatterns = null;
+
+    public function __construct(
+        private readonly TranslationKeyFilter $filter,
+    ) {}
+
+    /**
+     * Full scan. Returns an indexed list of unique keys + a per-key location map.
+     *
+     * @param string[] $linkedPackages absolute paths of extra scan roots
+     * @return array{keys: string[], locations: array<string, array<int, array{file:string, line:int, context:string}>>}
+     */
+    public function scan(array $linkedPackages = [], bool $universalDetection = false, bool $includePlainText = false): array
+    {
+        $this->filter->allowPlainText = $includePlainText;
+
+        $finder = $this->buildCodeFilesFinder($linkedPackages);
+
+        $keys      = [];
+        $locations = [];
+
+        foreach ($finder as $file) {
+            $path     = $file->getRealPath();
+            $filename = $file->getFilename();
+            if ($this->shouldSkipFile($filename, $path)) {
+                continue;
+            }
+            $content = file_get_contents($path);
+            $this->dynamicDetector()->collect($content);
+
+            foreach ($this->extractKeysFromContent($content, $path, $universalDetection) as $hit) {
+                $key = $hit['key'];
+                $keys[] = $key;
+
+                $rel = str_replace(base_path() . DIRECTORY_SEPARATOR, '', $path);
+                $locations[$key] ??= [];
+                $locations[$key][] = [
+                    'file'    => $rel,
+                    'line'    => $hit['line'],
+                    'context' => $hit['context'],
+                ];
+            }
+        }
+
+        return [
+            'keys'      => array_values(array_unique($keys)),
+            'locations' => $locations,
+        ];
+    }
+
+    /**
+     * Shared Finder used both by scan() and by the obsolete-detection
+     * literal-grep rescue pass. Ensures both walk exactly the same file set.
+     *
+     * @param string[] $linkedPackages
+     * @param string[] $linkedReal realpath-resolved copy of $linkedPackages
+     */
+    public function buildCodeFilesFinder(array $linkedPackages = [], ?array $linkedReal = null): Finder
+    {
+        $linkedReal ??= array_filter(array_map('realpath', $linkedPackages));
+
+        $finder = (new Finder())
+            ->files()
+            ->in(base_path())
+            ->name('*.php')->name('*.blade.php')->name('*.vue')->name('*.js')->name('*.ts')
+            ->exclude('node_modules')
+            ->exclude('storage')
+            ->exclude('bootstrap/cache')
+            ->exclude('public')
+            ->notName('*.lock')->notName('*.min.js')->notName('*.min.css')
+            ->notPath('*/migrations/*')
+            ->notPath('*/seeders/*')
+            ->notPath('*/factories/*')
+            ->notPath('*/tests/*')
+            ->notPath('*/Test*')
+            ->notPath('*/_ide_helper*')
+            ->notPath('*/config/cache/*')
+            ->notPath('*/lang/*')
+            ->notPath('*/resources/lang/*');
+
+        foreach ($linkedPackages as $path) {
+            if (is_dir($path)) {
+                $finder->in($path);
+            }
+        }
+
+        return $finder->filter(function (\SplFileInfo $file) use ($linkedReal) {
+            $path = $file->getRealPath();
+
+            foreach ($linkedReal as $linked) {
+                if ($linked && strpos($path, $linked . DIRECTORY_SEPARATOR) === 0) {
+                    return true;
+                }
+            }
+
+            if (strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR) === false) {
+                return true;
+            }
+            if (strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'condoedge' . DIRECTORY_SEPARATOR) !== false
+                || strpos($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'kompo' . DIRECTORY_SEPARATOR) !== false) {
+                return true;
+            }
+            return false;
+        });
+    }
+
+    public function dynamicDetector(): DynamicPrefixDetector
+    {
+        return $this->dynamicDetector ??= new DynamicPrefixDetector(self::TRANSLATION_FUNCTIONS);
+    }
+
+    // ------------------------------------------------------------------ internals
+
+    /**
+     * @return array<int, array{key:string, line:int, context:string}>
+     */
+    private function extractKeysFromContent(string $content, string $filepath, bool $universalDetection): array
+    {
+        if ($this->shouldSkipContent($content)) {
+            return [];
+        }
+
+        $results  = [];
+        $lines    = explode("\n", $content);
+        $patterns = $this->literalPatterns ??= $this->buildLiteralPatterns();
+
+        foreach ($patterns as $pattern) {
+            if (!preg_match_all($pattern, $content, $matches, PREG_OFFSET_CAPTURE)) {
+                continue;
+            }
+            foreach ($matches[1] as $match) {
+                $this->appendHit($results, $content, $lines, $match);
+            }
+        }
+
+        if ($universalDetection && $this->isUiFile($filepath, $content)) {
+            if (preg_match_all(self::UNIVERSAL_KEY_REGEX, $content, $matches, PREG_OFFSET_CAPTURE)) {
+                foreach ($matches[1] as $match) {
+                    $this->appendHit($results, $content, $lines, $match);
+                }
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param array<int, array{key:string, line:int, context:string}> $results
+     * @param array{0:string, 1:int} $match (PREG_OFFSET_CAPTURE pair)
+     */
+    private function appendHit(array &$results, string $content, array $lines, array $match): void
+    {
+        $key    = trim($match[0]);
+        $offset = $match[1];
+        if (!$this->filter->isValidKey($key, $this->getMatchContext($content, $key))) {
+            return;
+        }
+
+        $lineNumber   = substr_count(substr($content, 0, $offset), "\n") + 1;
+        $contextStart = max(0, $lineNumber - 3);
+        $contextEnd   = min(count($lines), $lineNumber + 2);
+        $snippet      = implode("\n", array_slice($lines, $contextStart, $contextEnd - $contextStart));
+
+        $results[] = [
+            'key'     => $key,
+            'line'    => $lineNumber,
+            'context' => $snippet,
+        ];
+    }
+
+    /**
+     * Build every literal-capture regex from TRANSLATION_FUNCTIONS + EXTRA_LITERAL_PATTERNS.
+     * @return array<string, string>
+     */
+    private function buildLiteralPatterns(): array
+    {
+        $patterns = [];
+        foreach (self::TRANSLATION_FUNCTIONS as $fn) {
+            $head    = ($fn['lookbehind'] ?? '') . $fn['regex'];
+            $closing = !empty($fn['multi_arg']) ? '[),]' : '\)';
+
+            if (!empty($fn['is_raw_prefix'])) {
+                $patterns[$fn['regex']] = '/' . $head . '[\'"]([^\'"]+)[\'"]/u';
+                continue;
+            }
+
+            $patterns[$fn['regex']] = '/' . $head . '\s*\(\s*[\'"]([^\'"]+)[\'"]\s*' . $closing . '/u';
+
+            if (!empty($fn['named_arg'])) {
+                $patterns[$fn['regex'] . '__named'] = '/' . $head . '\s*\(\s*key:\s*[\'"]([^\'"]+)[\'"]\s*[,)]/u';
+            }
+        }
+
+        foreach (self::EXTRA_LITERAL_PATTERNS as $name => $pattern) {
+            $patterns[$name] = $pattern;
+        }
+
+        return $patterns;
+    }
+
+    private function getMatchContext(string $content, string $match): string
+    {
+        $position = strpos($content, $match);
+        if ($position === false) {
+            return '';
+        }
+        $start = max(0, $position - 40);
+        return substr($content, $start, $position - $start);
+    }
+
+    private function shouldSkipFile(string $filename, string $filepath): bool
+    {
+        $exclusions = self::FILE_EXCLUSIONS;
+
+        if (in_array($filename, $exclusions['files'], true)) {
+            return true;
+        }
+        foreach ($exclusions['patterns'] as $pattern) {
+            if (preg_match($pattern, $filename)) {
+                return true;
+            }
+        }
+        foreach ($exclusions['paths'] as $path) {
+            if (strpos($filepath, $path) !== false) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function shouldSkipContent(string $content): bool
+    {
+        $skipPatterns = [
+            '/composer\.lock/', '/node_modules/', '/vendor\/\//',
+            '/^\s*\/\*\*/',
+        ];
+        foreach ($skipPatterns as $pattern) {
+            if (preg_match($pattern, $content)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function isUiFile(string $realPath, string $content): bool
+    {
+        $normalized = str_replace('\\', '/', $realPath);
+
+        foreach (self::UNIVERSAL_EXCLUDE_PATHS as $excluded) {
+            if (strpos($normalized, '/' . $excluded . '/') !== false) {
+                return false;
+            }
+        }
+
+        if (str_ends_with($normalized, '.blade.php') || str_ends_with($normalized, '.vue')) {
+            return true;
+        }
+
+        foreach (self::UI_PATH_MARKERS as $marker) {
+            if (strpos($normalized, $marker) !== false) {
+                return true;
+            }
+        }
+
+        if (preg_match('/enum\s+\w+[^{]*\{[^}]*function\s+label\s*\(/', $content)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Services/Translation/LocaleFilesRepository.php
+++ b/src/Services/Translation/LocaleFilesRepository.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Condoedge\Utils\Services\Translation;
+
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Owns all the filesystem I/O related to Laravel flat-JSON translation files
+ * (project resource_path('lang/<locale>.json')) plus a few sibling config
+ * files used by the analyzer tooling:
+ *
+ *   - resources/lang/<locale>.json           → canonical translation data
+ *   - storage/app/translator_linked_packages.json → user-linked local packages
+ *   - storage/app/translation_keys.json      → last analyzer index (cache)
+ *
+ * The repository exposes only pure-data methods. Display / CLI formatting
+ * stays in the caller (the Command).
+ */
+class LocaleFilesRepository
+{
+    public const JSON_OPTIONS = JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
+
+    private const LINKED_PACKAGES_FILE = 'translator_linked_packages.json';
+    private const INDEX_CACHE_FILE     = 'translation_keys.json';
+    private const INDEX_CACHE_KEY      = 'translation_keys';
+
+    // ---------------------------------------------------------------- lang JSON
+
+    public function load(string $locale): array
+    {
+        $path = resource_path("lang/{$locale}.json");
+        if (!is_file($path)) {
+            return [];
+        }
+        return json_decode(file_get_contents($path), true) ?: [];
+    }
+
+    /**
+     * Overwrite a locale file entirely. Callers are responsible for passing
+     * the final, already-sorted payload.
+     */
+    public function saveForLocale(string $locale, array $data): void
+    {
+        $path = resource_path("lang/{$locale}.json");
+        file_put_contents(
+            $path,
+            json_encode($data, self::JSON_OPTIONS) . "\n"
+        );
+    }
+
+    // ------------------------------------------------------------ locale config
+
+    /**
+     * Default locales from config, falling back to ['en', 'fr'].
+     * @return string[]
+     */
+    public function defaultLocales(): array
+    {
+        $configured = config('app.supported_locales');
+        if (is_array($configured) && !empty($configured)) {
+            return $configured;
+        }
+        return ['en', 'fr'];
+    }
+
+    /**
+     * Resolve the effective locale list: CLI override if provided, otherwise config defaults.
+     * @param string[] $cliLocales Output of Console->option('locale'), may be empty.
+     * @return string[]
+     */
+    public function resolveLocales(array $cliLocales = []): array
+    {
+        return !empty($cliLocales) ? $cliLocales : $this->defaultLocales();
+    }
+
+    // ----------------------------------------------------------- linked packages
+
+    /**
+     * @return string[] absolute paths the user has linked into the scan.
+     */
+    public function linkedPackages(): array
+    {
+        $path = storage_path('app/' . self::LINKED_PACKAGES_FILE);
+        if (!is_file($path)) {
+            return [];
+        }
+        $decoded = json_decode(file_get_contents($path), true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+        return array_values(array_filter($decoded, fn($p) => is_string($p) && $p !== ''));
+    }
+
+    public function saveLinkedPackages(array $paths): void
+    {
+        $path = storage_path('app/' . self::LINKED_PACKAGES_FILE);
+        @mkdir(dirname($path), 0755, true);
+        file_put_contents(
+            $path,
+            json_encode(array_values(array_unique($paths)), self::JSON_OPTIONS) . "\n"
+        );
+    }
+
+    // ----------------------------------------------------------- scanned-keys cache
+
+    /**
+     * Persist the list of translation keys discovered by the analyzer, both in
+     * the Laravel cache (for fast reuse from other code paths) and on disk for
+     * debugging and the Python GUI.
+     */
+    public function indexKeys(array $keys): void
+    {
+        Cache::put(self::INDEX_CACHE_KEY, $keys, now()->addDay());
+        file_put_contents(
+            storage_path('app/' . self::INDEX_CACHE_FILE),
+            json_encode($keys, JSON_PRETTY_PRINT) // historical format
+        );
+    }
+
+    // ---------------------------------------------------------------- reports
+
+    /**
+     * @return array<string, array{empty: string[], self_ref: string[]}>
+     */
+    public function emptyValuesReport(array $locales): array
+    {
+        $report = [];
+        foreach ($locales as $locale) {
+            $data    = $this->load($locale);
+            $empty   = [];
+            $selfRef = [];
+            foreach ($data as $key => $value) {
+                if (!is_string($value)) {
+                    continue;
+                }
+                $trim = trim($value);
+                if ($trim === '') {
+                    $empty[] = $key;
+                } elseif ($trim === $key) {
+                    $selfRef[] = $key;
+                }
+            }
+            $report[$locale] = ['empty' => $empty, 'self_ref' => $selfRef];
+        }
+        return $report;
+    }
+
+    /**
+     * For each pair of locales, list the keys present in one but not in the other.
+     * @return array<string, string[]>   e.g. ['en_not_in_fr' => [...], 'fr_not_in_en' => [...]]
+     */
+    public function diffLocalesReport(array $locales): array
+    {
+        $keySets = [];
+        foreach ($locales as $locale) {
+            $keySets[$locale] = array_keys($this->load($locale));
+        }
+
+        $report = [];
+        foreach ($locales as $locale) {
+            foreach (array_diff($locales, [$locale]) as $other) {
+                $diffKey = "{$locale}_not_in_{$other}";
+                $report[$diffKey] = array_values(array_diff($keySets[$locale], $keySets[$other]));
+            }
+        }
+        return $report;
+    }
+}

--- a/src/Services/Translation/MissingTranslationChecker.php
+++ b/src/Services/Translation/MissingTranslationChecker.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Condoedge\Utils\Services\Translation;
+
+use Condoedge\Utils\Models\MissingTranslation;
+use Illuminate\Support\Facades\Lang;
+
+class MissingTranslationChecker implements MissingTranslationCheckerInterface
+{
+    public function __construct(
+        private readonly PhpArrayLangReader $phpArrayReader,
+    ) {}
+
+    public function has(string $key, string $locale): bool
+    {
+        app()->setLocale($locale);
+
+        if (Lang::has($key, $locale)) {
+            $value = Lang::get($key, [], $locale);
+            if (!is_string($value)) {
+                return true;
+            }
+            $trim = trim($value);
+            if ($trim !== '' && $trim !== $key) {
+                return true;
+            }
+            // falls through to the vendor PHP-array fallback
+        }
+
+        // Many vendor packages ship `resources/lang/<locale>/<ns>.php` but forget
+        // to register them via loadTranslationsFrom(), so Lang::has() misses them.
+        if (str_contains($key, '.')) {
+            return $this->phpArrayReader->has($key, $locale);
+        }
+
+        return false;
+    }
+
+    public function find(array $keys, array $locales, bool $includeTriaged = false): array
+    {
+        [$skipGlobal, $skipPerLocale] = $this->triageSkipRules($keys, $includeTriaged);
+
+        $missing = [];
+        foreach ($locales as $locale) {
+            $missing[$locale] = [];
+            foreach ($keys as $key) {
+                if (isset($skipGlobal[$key]) || isset($skipPerLocale[$key][$locale])) {
+                    continue;
+                }
+                if (!$this->has($key, $locale)) {
+                    $missing[$locale][] = $key;
+                }
+            }
+        }
+        return $missing;
+    }
+
+    /**
+     * Load the {fixed,ignored} state from the DB so the report can skip keys
+     * the user has already triaged (unless `$includeTriaged` overrides that).
+     *
+     * @return array{0: array<string, true>, 1: array<string, array<string, true>>}
+     */
+    private function triageSkipRules(array $keys, bool $includeTriaged): array
+    {
+        if ($includeTriaged || empty($keys)) {
+            return [[], []];
+        }
+
+        $rows = MissingTranslation::query()
+            ->whereIn('translation_key', $keys)
+            ->where(fn($q) => $q->whereNotNull('ignored_at')->orWhereNotNull('fixed_at'))
+            ->get(['translation_key', 'locale', 'ignored_at', 'fixed_at']);
+
+        $global    = [];
+        $perLocale = [];
+        foreach ($rows as $row) {
+            if (empty($row->locale)) {
+                $global[$row->translation_key] = true;
+            } else {
+                $perLocale[$row->translation_key][$row->locale] = true;
+            }
+        }
+        return [$global, $perLocale];
+    }
+}

--- a/src/Services/Translation/MissingTranslationCheckerInterface.php
+++ b/src/Services/Translation/MissingTranslationCheckerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Condoedge\Utils\Services\Translation;
+
+/**
+ * Pure logic for deciding which translation keys are missing in a given
+ * locale. Implementations must be stateless and side-effect-free (no DB
+ * writes, no logging) — persistence and output formatting are caller concerns.
+ */
+interface MissingTranslationCheckerInterface
+{
+    /**
+     * True when `$key` has a non-empty, non-self-referencing translation
+     * available to Laravel in `$locale` (directly via `Lang::has()` or via
+     * a vendor package's PHP-array lang file).
+     */
+    public function has(string $key, string $locale): bool;
+
+    /**
+     * Scan `$keys` against every `$locale` and return the ones without a
+     * valid translation, keyed by locale.
+     *
+     * @param string[] $keys
+     * @param string[] $locales
+     * @return array<string, string[]>  e.g. ['en' => ['foo','bar'], 'fr' => ['baz']]
+     */
+    public function find(array $keys, array $locales, bool $includeTriaged = false): array;
+}

--- a/src/Services/Translation/MissingTranslationRecord.php
+++ b/src/Services/Translation/MissingTranslationRecord.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Condoedge\Utils\Services\Translation;
+
+/**
+ * Immutable record representing a single (translation_key, locale) entry in
+ * the JSON-backed {@see MissingTranslationsStore}. Replaces the old Eloquent
+ * model used before the DB was removed.
+ *
+ * The `id` is a deterministic hash of `<key>:<locale>` so Kompo UI actions
+ * (markAsFixed/markAsIgnored) can address rows without a DB auto-increment.
+ */
+class MissingTranslationRecord
+{
+    public readonly string $id;
+
+    public function __construct(
+        public readonly string $translation_key,
+        public readonly ?string $locale,
+        public readonly int $hit_count = 0,
+        public readonly ?string $last_seen_at = null,
+        public readonly ?string $fixed_at = null,
+        public readonly ?string $ignored_at = null,
+        public readonly ?string $package = null,
+        public readonly ?string $file_path = null,
+    ) {
+        $this->id = self::makeId($translation_key, $locale);
+    }
+
+    public static function makeId(string $translationKey, ?string $locale): string
+    {
+        return md5($translationKey . ':' . ($locale ?? ''));
+    }
+
+    /**
+     * @param array{
+     *   translation_key: string,
+     *   locale?: ?string,
+     *   hit_count?: int,
+     *   last_seen_at?: ?string,
+     *   fixed_at?: ?string,
+     *   ignored_at?: ?string,
+     *   package?: ?string,
+     *   file_path?: ?string
+     * } $data
+     */
+    public static function fromArray(string $key, ?string $locale, array $data): self
+    {
+        return new self(
+            translation_key: $key,
+            locale: $locale,
+            hit_count: (int) ($data['hit_count'] ?? 0),
+            last_seen_at: $data['last_seen_at'] ?? null,
+            fixed_at: $data['fixed_at'] ?? null,
+            ignored_at: $data['ignored_at'] ?? null,
+            package: $data['package'] ?? null,
+            file_path: $data['file_path'] ?? null,
+        );
+    }
+
+    /**
+     * Shape used inside the JSON file (under `data[key][locale_or_empty]`).
+     *
+     * @return array{hit_count: int, last_seen_at: ?string, fixed_at: ?string, ignored_at: ?string, package: ?string, file_path: ?string}
+     */
+    public function toStorageArray(): array
+    {
+        return [
+            'hit_count'    => $this->hit_count,
+            'last_seen_at' => $this->last_seen_at,
+            'fixed_at'     => $this->fixed_at,
+            'ignored_at'   => $this->ignored_at,
+            'package'      => $this->package,
+            'file_path'    => $this->file_path,
+        ];
+    }
+}

--- a/src/Services/Translation/MissingTranslationsQuery.php
+++ b/src/Services/Translation/MissingTranslationsQuery.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Condoedge\Utils\Services\Translation;
+
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Collection;
+
+/**
+ * Minimal chainable wrapper around a {@see Collection} of
+ * {@see MissingTranslationRecord} that mimics the subset of Eloquent's query
+ * builder actually used by the rewritten Kompo table and the mark/email
+ * commands. Built on Laravel's Collection — no database involved.
+ */
+class MissingTranslationsQuery
+{
+    /**
+     * @param Collection<int, MissingTranslationRecord> $records  current filtered set
+     * @param Collection<int, MissingTranslationRecord>|null $original  set `where()` closures fall back to for OR clauses
+     */
+    public function __construct(
+        private Collection $records,
+        private ?Collection $original = null,
+    ) {
+        $this->original ??= $records;
+    }
+
+    // ---------------------------------------------------------------- filters
+
+    public function when(bool $condition, \Closure $callback): self
+    {
+        return $condition ? ($callback($this) ?? $this) : $this;
+    }
+
+    public function where(\Closure|string $fieldOrClosure, mixed $value = null): self
+    {
+        if ($fieldOrClosure instanceof \Closure) {
+            // Closure = AND-group: evaluate sub-query scoped to the CURRENT records,
+            // then intersect by id so OR clauses inside only look up rows this
+            // outer query already kept.
+            $nested = $fieldOrClosure(new self($this->records, $this->records));
+            if ($nested instanceof self) {
+                $ids = $nested->records->pluck('id')->all();
+                return new self(
+                    $this->records->filter(fn($r) => in_array($r->id, $ids, true))->values(),
+                    $this->original,
+                );
+            }
+            return $this;
+        }
+        return new self(
+            $this->records->filter(fn($r) => $this->field($r, $fieldOrClosure) === $value)->values(),
+            $this->original,
+        );
+    }
+
+    public function whereIn(string $field, array $values): self
+    {
+        return new self(
+            $this->records->filter(fn($r) => in_array($this->field($r, $field), $values, true))->values(),
+            $this->original,
+        );
+    }
+
+    public function whereNull(string $field): self
+    {
+        return new self(
+            $this->records->filter(fn($r) => $this->field($r, $field) === null)->values(),
+            $this->original,
+        );
+    }
+
+    public function whereNotNull(string $field): self
+    {
+        return new self(
+            $this->records->filter(fn($r) => $this->field($r, $field) !== null)->values(),
+            $this->original,
+        );
+    }
+
+    /**
+     * Union with the original (pre-filter) baseline: keep rows where $field is
+     * NOT NULL, in addition to whatever the current chain already matched.
+     */
+    public function orWhereNotNull(string $field): self
+    {
+        $extra = $this->original->filter(fn($r) => $this->field($r, $field) !== null);
+        $merged = $this->records->merge($extra)->unique(fn($r) => $r->id)->values();
+        return new self($merged, $this->original);
+    }
+
+    // ---------------------------------------------------------------- terminal
+
+    /**
+     * The $columns argument is accepted for Eloquent API parity but ignored —
+     * records are in-memory DTOs, we don't project columns.
+     *
+     * @return Collection<int, MissingTranslationRecord>
+     */
+    public function get(array $columns = []): Collection
+    {
+        return $this->records;
+    }
+
+    public function first(): ?MissingTranslationRecord
+    {
+        return $this->records->first();
+    }
+
+    public function count(): int
+    {
+        return $this->records->count();
+    }
+
+    public function paginate(int $perPage = 15, ?int $page = null): LengthAwarePaginator
+    {
+        $page ??= Paginator::resolveCurrentPage();
+        $total = $this->records->count();
+        $items = $this->records->forPage($page, $perPage)->values();
+
+        return new LengthAwarePaginator(
+            $items,
+            $total,
+            $perPage,
+            $page,
+            ['path' => Paginator::resolveCurrentPath()],
+        );
+    }
+
+    // ---------------------------------------------------------------- internal
+
+    private function field(MissingTranslationRecord $record, string $name): mixed
+    {
+        return match ($name) {
+            'id'              => $record->id,
+            'translation_key' => $record->translation_key,
+            'locale'          => $record->locale,
+            'hit_count'       => $record->hit_count,
+            'last_seen_at'    => $record->last_seen_at,
+            'fixed_at'        => $record->fixed_at,
+            'ignored_at'      => $record->ignored_at,
+            'package'         => $record->package,
+            'file_path'       => $record->file_path,
+            default           => null,
+        };
+    }
+}

--- a/src/Services/Translation/MissingTranslationsStore.php
+++ b/src/Services/Translation/MissingTranslationsStore.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace Condoedge\Utils\Services\Translation;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * JSON-backed persistence layer for missing-translation tracking. Replaces
+ * the old Eloquent {@see \Condoedge\Utils\Models\MissingTranslation} table.
+ *
+ * File layout (storage/app/missing_translations.json):
+ *
+ *   {
+ *     "events.save": {
+ *       "fr": { "hit_count": 5, "last_seen_at": "...", "fixed_at": null, "ignored_at": null, "package": "...", "file_path": "..." },
+ *       "en": { ... }
+ *     },
+ *     ...
+ *   }
+ *
+ * A row with `locale === null` is stored under the empty-string key `""`.
+ *
+ * Concurrency: all writes go through {@see mutate()} which holds an exclusive
+ * flock on the JSON file and swaps the new contents via atomic rename. Reads
+ * are cached in the Laravel cache for 1 day per (key, locale) pair.
+ */
+class MissingTranslationsStore
+{
+    public const JSON_OPTIONS = JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
+
+    private const STORE_FILE = 'missing_translations.json';
+    private const CACHE_PREFIX = 'translation_missing_';
+
+    // --------------------------------------------------------------- path
+    public function path(): string
+    {
+        return storage_path('app/' . self::STORE_FILE);
+    }
+
+    // --------------------------------------------------------------- read
+    /**
+     * Whole store as a flat collection, one entry per (key, locale).
+     * @return Collection<int, MissingTranslationRecord>
+     */
+    public function all(): Collection
+    {
+        $data = $this->load();
+        $records = [];
+        foreach ($data as $key => $perLocale) {
+            if (!is_array($perLocale)) {
+                continue;
+            }
+            foreach ($perLocale as $localeKey => $payload) {
+                $records[] = MissingTranslationRecord::fromArray(
+                    $key,
+                    $localeKey === '' ? null : $localeKey,
+                    is_array($payload) ? $payload : [],
+                );
+            }
+        }
+        return collect($records);
+    }
+
+    public function find(string $key, ?string $locale): ?MissingTranslationRecord
+    {
+        $cacheKey = self::CACHE_PREFIX . $key . ':' . ($locale ?? '*');
+        $cached = Cache::get($cacheKey);
+        if ($cached instanceof MissingTranslationRecord) {
+            return $cached;
+        }
+
+        $data = $this->load();
+        $localeKey = $locale ?? '';
+        if (!isset($data[$key][$localeKey])) {
+            return null;
+        }
+
+        $record = MissingTranslationRecord::fromArray($key, $locale, $data[$key][$localeKey]);
+        Cache::put($cacheKey, $record, now()->addDay());
+        return $record;
+    }
+
+    public function findById(string $id): ?MissingTranslationRecord
+    {
+        return $this->all()->first(fn(MissingTranslationRecord $r) => $r->id === $id);
+    }
+
+    /**
+     * @return Collection<int, MissingTranslationRecord>
+     */
+    public function unresolved(?string $locale = null): Collection
+    {
+        return $this->all()
+            ->filter(fn(MissingTranslationRecord $r) => $r->fixed_at === null && $r->ignored_at === null)
+            ->when($locale !== null, fn($c) => $c->filter(fn($r) => $r->locale === $locale))
+            ->values();
+    }
+
+    public function query(): MissingTranslationsQuery
+    {
+        return new MissingTranslationsQuery($this->all());
+    }
+
+    // --------------------------------------------------------------- write
+    /**
+     * Upsert a single entry, incrementing hit_count and refreshing last_seen_at.
+     */
+    public function upsert(
+        string $key,
+        ?string $locale,
+        ?string $package = null,
+        ?string $filePath = null,
+    ): MissingTranslationRecord {
+        return $this->mutate(function (array &$data) use ($key, $locale, $package, $filePath) {
+            $localeKey = $locale ?? '';
+            $entry = $data[$key][$localeKey] ?? [];
+
+            $entry['hit_count']    = ((int) ($entry['hit_count'] ?? 0)) + 1;
+            $entry['last_seen_at'] = now()->toIso8601String();
+            $entry['fixed_at']     = $entry['fixed_at']   ?? null;
+            $entry['ignored_at']   = $entry['ignored_at'] ?? null;
+            $entry['package']      = $package  ?: ($entry['package']   ?? null);
+            $entry['file_path']    = $filePath ?: ($entry['file_path'] ?? null);
+
+            $data[$key][$localeKey] = $entry;
+
+            $record = MissingTranslationRecord::fromArray($key, $locale, $entry);
+            $this->bustCache($key, $locale);
+            Cache::put(self::CACHE_PREFIX . $key . ':' . ($locale ?? '*'), $record, now()->addDay());
+            return $record;
+        });
+    }
+
+    /**
+     * Bulk upsert used by {@see TrackingTranslator} so every request only
+     * pays one flock + read + write for all the misses it accumulated.
+     *
+     * @param array<int, array{key: string, locale: ?string, package?: ?string, file_path?: ?string}> $hits
+     */
+    public function flushBatch(array $hits): void
+    {
+        if (empty($hits)) {
+            return;
+        }
+        $this->mutate(function (array &$data) use ($hits) {
+            $now = now()->toIso8601String();
+            foreach ($hits as $hit) {
+                $key       = $hit['key'];
+                $locale    = $hit['locale'] ?? null;
+                $localeKey = $locale ?? '';
+                $entry     = $data[$key][$localeKey] ?? [];
+
+                $entry['hit_count']    = ((int) ($entry['hit_count'] ?? 0)) + 1;
+                $entry['last_seen_at'] = $now;
+                $entry['fixed_at']     = $entry['fixed_at']   ?? null;
+                $entry['ignored_at']   = $entry['ignored_at'] ?? null;
+                $entry['package']      = ($hit['package']   ?? null) ?: ($entry['package']   ?? null);
+                $entry['file_path']    = ($hit['file_path'] ?? null) ?: ($entry['file_path'] ?? null);
+
+                $data[$key][$localeKey] = $entry;
+                $this->bustCache($key, $locale);
+            }
+            return null;
+        });
+    }
+
+    public function markFixed(string $id): ?MissingTranslationRecord
+    {
+        return $this->stamp($id, 'fixed_at', now()->toIso8601String());
+    }
+
+    public function markIgnored(string $id): ?MissingTranslationRecord
+    {
+        return $this->stamp($id, 'ignored_at', now()->toIso8601String());
+    }
+
+    public function reset(string $id): ?MissingTranslationRecord
+    {
+        return $this->mutate(function (array &$data) use ($id) {
+            foreach ($data as $key => &$perLocale) {
+                foreach ($perLocale as $localeKey => &$entry) {
+                    $locale = $localeKey === '' ? null : $localeKey;
+                    if (MissingTranslationRecord::makeId($key, $locale) !== $id) {
+                        continue;
+                    }
+                    $entry['fixed_at']   = null;
+                    $entry['ignored_at'] = null;
+                    $this->bustCache($key, $locale);
+                    return MissingTranslationRecord::fromArray($key, $locale, $entry);
+                }
+            }
+            return null;
+        });
+    }
+
+    public function delete(string $id): bool
+    {
+        return (bool) $this->mutate(function (array &$data) use ($id) {
+            foreach ($data as $key => $perLocale) {
+                foreach ($perLocale as $localeKey => $_) {
+                    $locale = $localeKey === '' ? null : $localeKey;
+                    if (MissingTranslationRecord::makeId($key, $locale) !== $id) {
+                        continue;
+                    }
+                    unset($data[$key][$localeKey]);
+                    if (empty($data[$key])) {
+                        unset($data[$key]);
+                    }
+                    $this->bustCache($key, $locale);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    // --------------------------------------------------------------- internals
+
+    /**
+     * Tag + overwrite helper.
+     */
+    private function stamp(string $id, string $field, string $when): ?MissingTranslationRecord
+    {
+        return $this->mutate(function (array &$data) use ($id, $field, $when) {
+            foreach ($data as $key => &$perLocale) {
+                foreach ($perLocale as $localeKey => &$entry) {
+                    $locale = $localeKey === '' ? null : $localeKey;
+                    if (MissingTranslationRecord::makeId($key, $locale) !== $id) {
+                        continue;
+                    }
+                    $entry[$field] = $when;
+                    $this->bustCache($key, $locale);
+                    return MissingTranslationRecord::fromArray($key, $locale, $entry);
+                }
+            }
+            return null;
+        });
+    }
+
+    /**
+     * Exclusive file-locked read-modify-write, with atomic rename on save.
+     * $callback receives the current data by reference and returns an arbitrary
+     * value that is bubbled back to the caller.
+     *
+     * @template T
+     * @param callable(array &$data): T $callback
+     * @return T
+     */
+    private function mutate(callable $callback)
+    {
+        $path = $this->path();
+        @mkdir(dirname($path), 0755, true);
+
+        // Ensure the file exists so flock can lock it.
+        if (!is_file($path)) {
+            file_put_contents($path, "{}\n");
+        }
+
+        $handle = fopen($path, 'c+');
+        if ($handle === false) {
+            throw new \RuntimeException("Cannot open missing_translations store at {$path}");
+        }
+
+        try {
+            if (!flock($handle, LOCK_EX)) {
+                throw new \RuntimeException('Cannot acquire exclusive lock on missing_translations store');
+            }
+            rewind($handle);
+            $raw     = stream_get_contents($handle) ?: '{}';
+            $decoded = json_decode($raw, true);
+            $data    = is_array($decoded) ? $decoded : [];
+
+            $result = $callback($data);
+
+            // Rewrite through the same locked handle — the classic rename-over
+            // atomic swap fails on Windows when the target is still flock-held.
+            $payload = json_encode($data, self::JSON_OPTIONS) . "\n";
+            rewind($handle);
+            ftruncate($handle, 0);
+            fwrite($handle, $payload);
+            fflush($handle);
+            return $result;
+        } finally {
+            @flock($handle, LOCK_UN);
+            @fclose($handle);
+        }
+    }
+
+    private function load(): array
+    {
+        $path = $this->path();
+        if (!is_file($path)) {
+            return [];
+        }
+        $decoded = json_decode(file_get_contents($path) ?: '[]', true);
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function bustCache(string $key, ?string $locale): void
+    {
+        Cache::forget(self::CACHE_PREFIX . $key . ':' . ($locale ?? '*'));
+        Cache::forget(self::CACHE_PREFIX . $key . ':*');
+        Cache::forget(self::CACHE_PREFIX . $key);
+    }
+}

--- a/src/Services/Translation/ObsoleteKeyDetector.php
+++ b/src/Services/Translation/ObsoleteKeyDetector.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Condoedge\Utils\Services\Translation;
+
+/**
+ * Finds keys that live in a locale JSON file but are never referenced from
+ * PHP/Blade/Vue/JS/TS source. Runs in two passes:
+ *
+ *   1. compare each locale's JSON against the list of keys the
+ *      {@see KeyCodeScanner} extracted, dropping anything that matches a
+ *      dynamic prefix (e.g. `<ns>.` when code does __("<ns>." . $var));
+ *   2. for the remaining candidates, grep the whole codebase for the key as
+ *      a quoted string — if it appears anywhere, rescue it from the report.
+ */
+class ObsoleteKeyDetector
+{
+    public function __construct(
+        private readonly LocaleFilesRepository $localeFiles,
+        private readonly KeyCodeScanner $codeScanner,
+    ) {}
+
+    /**
+     * @param string[] $usedKeys  keys extracted by {@see KeyCodeScanner::scan()}
+     * @param string[] $locales
+     * @return array{
+     *   report: array<string, string[]>,
+     *   skippedByDynamicPrefix: int,
+     *   rescued: int,
+     *   prefixes: string[]
+     * }
+     */
+    public function detect(array $usedKeys, array $locales): array
+    {
+        $usedSet                = array_flip($usedKeys);
+        $candidatesPerLocale    = [];
+        $allCandidates          = [];
+        $skippedByDynamicPrefix = 0;
+
+        foreach ($locales as $locale) {
+            $data       = $this->localeFiles->load($locale);
+            $candidates = [];
+            foreach (array_keys($data) as $key) {
+                if (isset($usedSet[$key])) {
+                    continue;
+                }
+                if ($this->codeScanner->dynamicDetector()->matches($key)) {
+                    $skippedByDynamicPrefix++;
+                    continue;
+                }
+                $candidates[]         = $key;
+                $allCandidates[$key]  = true;
+            }
+            $candidatesPerLocale[$locale] = $candidates;
+        }
+
+        $reallyObsolete = $this->filterByLiteralGrep(array_keys($allCandidates));
+
+        $report = [];
+        foreach ($candidatesPerLocale as $locale => $candidates) {
+            $report[$locale] = array_values(array_intersect($candidates, $reallyObsolete));
+        }
+
+        return [
+            'report'                 => $report,
+            'skippedByDynamicPrefix' => $skippedByDynamicPrefix,
+            'rescued'                => count($allCandidates) - count($reallyObsolete),
+            'prefixes'               => $this->codeScanner->dynamicDetector()->prefixes(),
+        ];
+    }
+
+    /**
+     * Slurp every scanned source file once, then check every candidate for a
+     * quoted-literal occurrence. Same file set as {@see KeyCodeScanner::scan()}.
+     *
+     * @param string[] $candidates
+     * @return string[]
+     */
+    private function filterByLiteralGrep(array $candidates): array
+    {
+        if (empty($candidates)) {
+            return [];
+        }
+
+        $haystack = '';
+        foreach ($this->codeScanner->buildCodeFilesFinder($this->localeFiles->linkedPackages()) as $file) {
+            $haystack .= file_get_contents($file->getRealPath()) . "\n";
+        }
+
+        $reallyObsolete = [];
+        foreach ($candidates as $key) {
+            if (
+                !str_contains($haystack, "'" . $key . "'")
+                && !str_contains($haystack, '"' . $key . '"')
+            ) {
+                $reallyObsolete[] = $key;
+            }
+        }
+        return $reallyObsolete;
+    }
+}

--- a/src/Services/Translation/PhpArrayLangReader.php
+++ b/src/Services/Translation/PhpArrayLangReader.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Condoedge\Utils\Services\Translation;
+
+/**
+ * Reads Laravel-style PHP array translation files from vendor packages.
+ *
+ * Many packages ship `resources/lang/<locale>/<namespace>.php` files that return
+ * a PHP array, but forget to call `loadTranslationsFrom()` in their service
+ * provider. The framework then can't find those keys via `Lang::has()`.
+ *
+ * This reader scans such files directly so the analyzer can still tell the user
+ * "the key exists, it's just not registered".
+ *
+ * Key shape expected: `<namespace>.<array_key>` (e.g. `cms.add-zone`).
+ * Nested array keys are supported: `cms.a.b.c` → namespace `cms`, chain `a.b.c`.
+ */
+class PhpArrayLangReader
+{
+    /** @var array<string, array>  path => loaded array (per-request cache) */
+    private array $cache = [];
+
+    /**
+     * @return string[] list of scanned roots (vendor package roots with lang dirs)
+     */
+    public function discoverRoots(array $vendors = ['condoedge', 'kompo']): array
+    {
+        $roots = [];
+        foreach ($vendors as $v) {
+            $dir = base_path('vendor/' . $v);
+            if (!is_dir($dir)) {
+                continue;
+            }
+            foreach (glob($dir . '/*', GLOB_ONLYDIR) ?: [] as $pkg) {
+                $langDir = $pkg . '/resources/lang';
+                if (is_dir($langDir)) {
+                    $roots[] = $pkg;
+                }
+            }
+        }
+        return $roots;
+    }
+
+    /**
+     * Check whether `$key` (form `namespace.rest`) has a non-empty translation
+     * in any vendor PHP-array lang file for the given locale.
+     */
+    public function has(string $key, string $locale, ?array $roots = null): bool
+    {
+        $value = $this->get($key, $locale, $roots);
+        if (!is_string($value)) {
+            return $value !== null;  // array / nested group counts as present
+        }
+        $trim = trim($value);
+        return $trim !== '' && $trim !== $key;
+    }
+
+    /**
+     * Retrieve the translation value (string, array, or null if not found).
+     */
+    public function get(string $key, string $locale, ?array $roots = null)
+    {
+        if (!str_contains($key, '.')) {
+            return null;
+        }
+        [$namespace, $rest] = explode('.', $key, 2);
+
+        foreach ($roots ?? $this->discoverRoots() as $pkg) {
+            $file = $pkg . '/resources/lang/' . $locale . '/' . $namespace . '.php';
+            $data = $this->load($file);
+            if ($data === null) {
+                continue;
+            }
+            $value = $this->extractNested($data, $rest);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Flatten every PHP-array lang file under the given package into
+     * [ "<namespace>.<nested.key>" => "value", ... ].
+     */
+    public function flattenPackage(string $pkgPath, string $locale): array
+    {
+        $out = [];
+        $dir = $pkgPath . '/resources/lang/' . $locale;
+        if (!is_dir($dir)) {
+            return $out;
+        }
+        foreach (glob($dir . '/*.php') ?: [] as $file) {
+            $namespace = pathinfo($file, PATHINFO_FILENAME);
+            $data = $this->load($file);
+            if (!is_array($data)) {
+                continue;
+            }
+            $this->flattenInto($data, $namespace, $out);
+        }
+        return $out;
+    }
+
+    private function load(string $file): ?array
+    {
+        if (!is_file($file)) {
+            return null;
+        }
+        if (!array_key_exists($file, $this->cache)) {
+            try {
+                $data = include $file;
+                $this->cache[$file] = is_array($data) ? $data : null;
+            } catch (\Throwable $e) {
+                $this->cache[$file] = null;
+            }
+        }
+        return $this->cache[$file];
+    }
+
+    private function extractNested(array $data, string $chain)
+    {
+        $current = $data;
+        foreach (explode('.', $chain) as $part) {
+            if (!is_array($current) || !array_key_exists($part, $current)) {
+                return null;
+            }
+            $current = $current[$part];
+        }
+        return $current;
+    }
+
+    private function flattenInto(array $data, string $prefix, array &$out): void
+    {
+        foreach ($data as $k => $v) {
+            $full = $prefix . '.' . $k;
+            if (is_array($v)) {
+                $this->flattenInto($v, $full, $out);
+            } else {
+                $out[$full] = $v;
+            }
+        }
+    }
+}

--- a/src/Services/Translation/TrackingTranslator.php
+++ b/src/Services/Translation/TrackingTranslator.php
@@ -30,7 +30,11 @@ class TrackingTranslator extends Translator
             && preg_match('/^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+$/', $key)
             && $this->getKeyFilter()->isValidKey($key)) {
             try {
-                MissingTranslation::upsertMissingTranslation($key, $this->getPackage());
+                MissingTranslation::upsertMissingTranslation(
+                    $key,
+                    $this->getPackage(),
+                    $locale ?: $this->locale
+                );
             } catch (\Exception $e) {}
  
             return $translation;

--- a/src/Services/Translation/TrackingTranslator.php
+++ b/src/Services/Translation/TrackingTranslator.php
@@ -3,73 +3,117 @@
 namespace Condoedge\Utils\Services\Translation;
 
 use Illuminate\Translation\Translator;
-use Illuminate\Support\Facades\Log;
-use Condoedge\Utils\Models\MissingTranslation;
-use Condoedge\Utils\Services\Translation\TranslationKeyFilter;
 
+/**
+ * Translator decorator that records every key that falls through to the
+ * "key itself is the return value" branch — i.e. no translation was found
+ * for the current locale.
+ *
+ * Misses are accumulated in memory during the request and flushed to the
+ * JSON-backed {@see MissingTranslationsStore} once, in the terminating
+ * kernel callback. This avoids locking + writing the store on every
+ * single `__()` call (which would be catastrophic for request latency).
+ *
+ * Hits from a request that crashes before the terminate hook fires are
+ * lost — we considered that acceptable during the DB→JSON migration.
+ */
 class TrackingTranslator extends Translator
 {
-    /** @var TranslationKeyFilter|null */
-    private $keyFilter;
+    private ?TranslationKeyFilter $keyFilter = null;
+
     /**
-     * Get the translation for the given key.
+     * Buffered misses, keyed by `<key>:<locale>` so duplicates within the
+     * same request collapse into one upsert.
      *
-     * @param  string  $key
-     * @param  array  $replace
-     * @param  string|null  $locale
-     * @param  bool  $fallback
-     * @return string|array
+     * @var array<string, array{key: string, locale: ?string, package: ?string, file_path: ?string}>
+     */
+    private array $buffer = [];
+
+    private bool $flushRegistered = false;
+
+    /**
+     * @inheritDoc
      */
     public function get($key, array $replace = [], $locale = null, $fallback = true)
     {
         $translation = parent::get($key, $replace, $locale, $fallback);
 
-        // Record lazily only when key looks like a namespaced translation key
         if ($translation === $key
             && is_string($key)
             && preg_match('/^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+$/', $key)
             && $this->getKeyFilter()->isValidKey($key)) {
-            try {
-                MissingTranslation::upsertMissingTranslation(
-                    $key,
-                    $this->getPackage(),
-                    $locale ?: $this->locale
-                );
-            } catch (\Exception $e) {}
- 
-            return $translation;
+            $this->bufferMiss($key, $locale ?: $this->locale);
         }
-        
+
         return $translation;
+    }
+
+    private function bufferMiss(string $key, ?string $locale): void
+    {
+        $bufferKey = $key . ':' . ($locale ?? '');
+        if (!isset($this->buffer[$bufferKey])) {
+            $this->buffer[$bufferKey] = [
+                'key'       => $key,
+                'locale'    => $locale,
+                'package'   => $this->getPackage(),
+                'file_path' => null,
+            ];
+            $this->registerFlushOnce();
+        }
+    }
+
+    private function registerFlushOnce(): void
+    {
+        if ($this->flushRegistered) {
+            return;
+        }
+        $this->flushRegistered = true;
+
+        // Some test setups run outside a full Laravel kernel — guard both.
+        $app = function_exists('app') ? app() : null;
+        if ($app && method_exists($app, 'terminating')) {
+            $app->terminating(function () {
+                $this->flushBuffer();
+            });
+            return;
+        }
+        // Fallback: PHP shutdown hook.
+        register_shutdown_function(fn() => $this->flushBuffer());
+    }
+
+    private function flushBuffer(): void
+    {
+        if (empty($this->buffer)) {
+            return;
+        }
+        try {
+            app(MissingTranslationsStore::class)->flushBatch(array_values($this->buffer));
+        } catch (\Throwable $e) {
+            // Never let telemetry crash a request.
+        }
+        $this->buffer = [];
     }
 
     private function getKeyFilter(): TranslationKeyFilter
     {
-        if (!$this->keyFilter) {
-            $this->keyFilter = new TranslationKeyFilter();
-        }
-        return $this->keyFilter;
+        return $this->keyFilter ??= app(TranslationKeyFilter::class);
     }
 
-    protected function getPackage()
+    protected function getPackage(): ?string
     {
-        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
-        $backtrace = array_slice($backtrace, 2); // Skip first two frames (this method and get method)
-
+        $backtrace = array_slice(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10), 2);
         foreach ($backtrace as $trace) {
-            $class = $trace['class'] ?? null;
+            $class    = $trace['class']    ?? null;
             $function = $trace['function'] ?? null;
-            $file = $trace['file'] ?? null;
+            $file     = $trace['file']     ?? null;
 
-            if ($class && str_starts_with($class, 'Condoedge\\') || (str_starts_with($class, 'Kompo\\Auth'))) {
+            if ($class && (str_starts_with($class, 'Condoedge\\') || str_starts_with($class, 'Kompo\\Auth'))) {
                 return $class;
             }
-
             if ($function && preg_match('/^_[A-Z]/', $function) && $file) {
                 return $file;
             }
         }
-        
         return null;
     }
 }

--- a/src/Services/Translation/TranslationKeyFilter.php
+++ b/src/Services/Translation/TranslationKeyFilter.php
@@ -155,32 +155,6 @@ class TranslationKeyFilter
 
     private function isExcludedKey(string $key): bool
     {
-        $excludedKeys = $this->getExcludedKeys();
-        return in_array($key, $excludedKeys, true);
-    }
-
-    private function getExcludedKeys(): array
-    {
-        $excludeFile = storage_path('app/translation_exclude_keys.json');
-
-        if (file_exists($excludeFile)) {
-            $content = file_get_contents($excludeFile);
-            $parsed = json_decode($content, true);
-            if (is_array($parsed)) return $parsed;
-        }
-
-        $defaultExcluded = [
-            '_CollapsibleSideSection', '_CollapsibleInnerSection', '_CollapsibleSideTitle', '_CollapsibleSideItem',
-            '_Button', '_Link', '_Flex', '_Html', '_Sax', '_Collapsible',
-            'class', 'id', 'href', 'src', 'alt', 'title', 'name', 'value', 'type',
-            'php', 'js', 'css', 'html', 'json', 'xml', 'api', 'admin',
-            'hidden', 'active', 'disabled', 'loading', 'home', 'login', 'logout'
-        ];
-
-        if (!file_exists($excludeFile)) {
-            @file_put_contents($excludeFile, json_encode($defaultExcluded, JSON_PRETTY_PRINT));
-        }
-
-        return $defaultExcluded;
+        return app(ExcludedKeysRepository::class)->contains($key);
     }
 }

--- a/src/Services/Translation/TranslationKeyFilter.php
+++ b/src/Services/Translation/TranslationKeyFilter.php
@@ -4,12 +4,18 @@ namespace Condoedge\Utils\Services\Translation;
 
 class TranslationKeyFilter
 {
+    /**
+     * When true, plain-text keys (letters + spaces only, no namespace) are allowed.
+     * Useful to detect flat-JSON keys like "Save changes" at the cost of more false positives.
+     */
+    public bool $allowPlainText = false;
+
     private const EXCLUSION_RULES = [
         'contexts' => [
             'config(', 'env(', '->get(', 'Config::', 'config/', 'config.',
             'rules(', 'validator(', 'validate(', 'Validator::', 'function_exists(',
             'class_exists(', 'method_exists(', 'interface_exists(', 'trait_exists(',
-            'defined(', 'constant(', 'storage_path(', 'resource_path(', '_Sax(', 
+            'defined(', 'constant(', 'storage_path(', 'resource_path(', '_Sax(',
             'icon(', 'svg(', 'path(', 'url(', 'route(', 'asset(',
             'Auth::', 'auth(', 'Gate::', 'gate(', 'DB::', 'db(',
             'Session::', 'session(', 'Cache::', 'cache(', 'Log::', 'log(',
@@ -18,6 +24,12 @@ class TranslationKeyFilter
             'Request::', 'request(', 'Route::', 'route(', 'URL::', 'url(',
             'Redirect::', 'redirect(', 'Schema::', 'schema(', 'Artisan::', 'artisan(',
             'Broadcast::', 'broadcast(', 'Password::', 'password(', 'Notification::', 'notification(',
+            // Non-translation Kompo/HTML method calls
+            '->id(', '->attr(', '->addHeader(', '->href(', '->src(', '->format(',
+            '->onKeyDown(', '->onClick(', '->onBlur(', '->onChange(',
+            '->inDrawer(', '->inPanel(', '->inModal(', // panel/modal target IDs
+            '->browse(', '->redirect(', '->emit(',
+            'addHeader(', '::class',
         ],
         'config_patterns' => [
             'app.', 'database.', 'cache.', 'queue.', 'mail.', 'session.',
@@ -48,7 +60,9 @@ class TranslationKeyFilter
             '/^(function|class|return)/',
             '/^validation\.values[^,]*$/', // validation.values.something
             '/^validation\.custom[^,]*$/', // validation.custom.something
-            '/^[a-zA-Z ]*$/' // only letters and spaces
+        ],
+        'plain_text_patterns' => [
+            '/^[a-zA-Z ]*$/',        // only letters and spaces — opt-in via $allowPlainText
         ]
     ];
 
@@ -117,13 +131,22 @@ class TranslationKeyFilter
             if (preg_match($pattern, $key)) return false;
         }
 
+        if (!$this->allowPlainText) {
+            foreach ($rules['plain_text_patterns'] as $pattern) {
+                if (preg_match($pattern, $key)) return false;
+            }
+        }
+
         return true;
     }
 
     private function isValidInContext(string $key, string $context): bool
     {
         foreach (self::EXCLUSION_RULES['contexts'] as $contextPattern) {
-            if (stripos($context, $contextPattern) !== false) {
+            // Word-boundary match so "->revalidate()" does NOT match "validate(",
+            // "->reconfigure()" does NOT match "config(", etc.
+            $escaped = preg_quote($contextPattern, '/');
+            if (preg_match('/(?<![a-zA-Z0-9_:>])' . $escaped . '/i', $context)) {
                 return false;
             }
         }

--- a/src/Services/Translation/VendorTranslationMerger.php
+++ b/src/Services/Translation/VendorTranslationMerger.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Condoedge\Utils\Services\Translation;
+
+/**
+ * Walks the configured vendor directories, collects every translation they
+ * ship (flat JSON + PHP-array lang files), and merges those entries into the
+ * project-level locale JSON — giving precedence to project translations.
+ *
+ * Returns a structured report so the caller (a CLI command, typically) can
+ * render it however it wants without mixing I/O and presentation here.
+ */
+class VendorTranslationMerger
+{
+    /**
+     * @var string[]  base_path-relative defaults (scanned when no override passed).
+     */
+    private const DEFAULT_VENDOR_PATHS = [
+        'vendor/condoedge',
+        'vendor/kompo',
+    ];
+
+    public function __construct(
+        private readonly LocaleFilesRepository $localeFiles,
+        private readonly PhpArrayLangReader $phpArrayReader,
+    ) {}
+
+    /**
+     * @param string[]|null $vendorPaths  null → {@see self::DEFAULT_VENDOR_PATHS}
+     * @param string[]|null $locales      null → {@see LocaleFilesRepository::defaultLocales()}
+     *
+     * @return array{
+     *   packageCount: int,
+     *   missingPaths: string[],
+     *   discoveries: array<int, array{package: string, locale: string, source: string, count: int}>,
+     *   merges: array<string, array{added: int, total: int}>
+     * }
+     */
+    public function merge(?array $vendorPaths = null, ?array $locales = null): array
+    {
+        $vendorPaths ??= self::DEFAULT_VENDOR_PATHS;
+        $locales     ??= $this->localeFiles->defaultLocales();
+
+        $mergedTranslations = array_fill_keys($locales, []);
+        $discoveries        = [];
+        $missingPaths       = [];
+        $packageCount       = 0;
+
+        foreach ($vendorPaths as $vendorPath) {
+            $fullPath = base_path($vendorPath);
+            if (!is_dir($fullPath)) {
+                $missingPaths[] = $vendorPath;
+                continue;
+            }
+
+            foreach (glob($fullPath . '/*', GLOB_ONLYDIR) ?: [] as $package) {
+                $packageName = basename(dirname($package)) . '/' . basename($package);
+
+                foreach ($locales as $locale) {
+                    $collected = $this->collectPackageTranslations($package, $locale);
+                    foreach ($collected as $source => $entries) {
+                        if (empty($entries)) {
+                            continue;
+                        }
+                        $discoveries[] = [
+                            'package' => $packageName,
+                            'locale'  => $locale,
+                            'source'  => $source,
+                            'count'   => count($entries),
+                        ];
+                        $mergedTranslations[$locale] = [...$mergedTranslations[$locale], ...$entries];
+                        $packageCount++;
+                    }
+                }
+            }
+        }
+
+        $merges = [];
+        if ($packageCount > 0) {
+            foreach ($locales as $locale) {
+                $project = $this->localeFiles->load($locale);
+                // Project translations win over vendor defaults.
+                $final = [...$mergedTranslations[$locale], ...$project];
+                ksort($final);
+                $this->localeFiles->saveForLocale($locale, $final);
+
+                $merges[$locale] = [
+                    'added' => count($final) - count($project),
+                    'total' => count($final),
+                ];
+            }
+        }
+
+        return [
+            'packageCount' => $packageCount,
+            'missingPaths' => $missingPaths,
+            'discoveries'  => $discoveries,
+            'merges'       => $merges,
+        ];
+    }
+
+    /**
+     * @return array{json: array<string, string>, php: array<string, string>}
+     */
+    private function collectPackageTranslations(string $package, string $locale): array
+    {
+        $out = ['json' => [], 'php' => []];
+
+        $jsonFile = $package . '/resources/lang/' . $locale . '.json';
+        if (file_exists($jsonFile)) {
+            $decoded = json_decode(file_get_contents($jsonFile), true);
+            if (is_array($decoded)) {
+                $out['json'] = $decoded;
+            }
+        }
+
+        $phpLangDir = $package . '/resources/lang/' . $locale;
+        if (is_dir($phpLangDir) && glob($phpLangDir . '/*.php')) {
+            $out['php'] = $this->phpArrayReader->flattenPackage($package, $locale);
+        }
+
+        return $out;
+    }
+}

--- a/tools/translator/README.md
+++ b/tools/translator/README.md
@@ -1,0 +1,113 @@
+# Translation Helper (desktop GUI)
+
+A tkinter desktop tool that walks through missing translation keys detected by
+`php artisan app:missing-translation-analyzer-command` and lets you write
+EN/FR pairs one at a time, with optional Claude-powered suggestions.
+
+Ships with the `condoedge/utils` package so any Laravel app that depends on it
+(SISC, Coolecto, future Decizif apps…) can use the same tool.
+
+## Prerequisites
+
+- Python 3.10+ (tkinter is part of the standard library on Windows).
+- PHP reachable on PATH.
+- Optional: `claude` CLI (Claude Code) for AI-assisted translations — no API
+  key needed, billing goes through each dev's own Claude subscription.
+
+## AI cost knobs
+
+The GUI calls `claude --print` once per key you Suggest or that the prefetch
+worker looks at. To keep Max-subscription usage under control, the tool has
+these defaults:
+
+- **Model: Haiku by default** (`claude-haiku-4-5-20251001`). Roughly 10× cheaper
+  than Sonnet, plenty for short UI labels.
+- **Wider file context disabled** — only the 5-line immediate snippet is sent.
+  Saves hundreds of tokens per call.
+
+Override via environment variables (set them before launching):
+
+```bash
+# Switch to Sonnet (better for complex phrases, more expensive)
+SISC_TRANSLATOR_MODEL=sonnet php artisan app:translator
+
+# Or pick a full model id
+SISC_TRANSLATOR_MODEL=claude-sonnet-4-6 php artisan app:translator
+
+# Include ±20 lines of file context when Haiku struggles with a label
+SISC_TRANSLATOR_WIDE_CONTEXT=1 php artisan app:translator
+```
+
+Tip: if you only translate a few keys by hand, leave Auto-prefetch OFF — each
+prefetched key is one CLI invocation.
+
+## Launch
+
+From any project root that has `condoedge/utils` installed:
+
+```bash
+# Easiest — via artisan wrapper
+php artisan app:translator
+
+# With an existing JSON export (skips the 20 s scan)
+php artisan app:missing-translation-analyzer-command --json > missing.json
+php artisan app:translator missing.json
+
+# Bypass artisan if you prefer
+python vendor/condoedge/utils/tools/translator/translator.py
+```
+
+## Keyboard shortcuts
+
+| Key          | Action                                                  |
+|--------------|---------------------------------------------------------|
+| `←` / `→`    | Prev / Next without saving                              |
+| `Ctrl+S`     | Save EN+FR and move to the next key                     |
+| `Ctrl+G`     | Ask Claude to suggest translations for the current key  |
+| `Esc`        | Close                                                   |
+
+## Actions
+
+| Button          | Writes JSON               | DB flag         | Notes                                                            |
+|-----------------|---------------------------|-----------------|------------------------------------------------------------------|
+| Save & Next     | ✅ for filled field(s)    | `fixed_at`      | Advances to the next key                                         |
+| Save & Close    | ✅ for all drafts         | `fixed_at` × N  | Flushes every entry you typed during the session                 |
+| Skip            | ❌                        | ❌              | Will re-appear on next scan                                      |
+| Ignore          | ❌                        | `ignored_at`    | Persistent — hidden from future scans unless `--include-triaged` |
+| 🤖 Suggest      | fields prefilled          | ❌              | Classifies the key too (non-translations highlight Ignore)       |
+| Auto-prefetch   | background                | ❌              | Pre-computes upcoming suggestions while you work                 |
+
+## What the AI sees
+
+For each key the prompt includes:
+
+1. The translation key itself (e.g. `discussions.today`).
+2. The immediate 5-line code context captured by the analyzer.
+3. ±20 lines from the real source file around the usage line, with a `→`
+   marker on the exact line.
+4. SISC-specific glossary enforced in the system prompt (Scout vs Member,
+   Volunteer vs Leader, Person, Brevet, Quebec French conventions, …).
+
+Response is classified into `is_translation_key: true|false`. When Claude
+thinks the string is NOT a UI key (icon name, CSS class, date format…), the
+GUI highlights the Ignore button and shows a hint.
+
+## Files touched
+
+| Path                                                 | Purpose                                |
+|------------------------------------------------------|----------------------------------------|
+| `resources/lang/en.json`, `resources/lang/fr.json`   | Canonical translation files (written)  |
+| `missing_translations` DB table                      | Status (fixed/ignored) + hit counts    |
+| `storage/app/translation_ignore_pending.json`        | Queue for `--exclude-key` batches      |
+| `storage/app/translation_keys.json`                  | Cache from the analyzer                |
+
+## Troubleshooting
+
+- **"claude CLI not found"** — the AI button is disabled. Install Claude Code
+  and run `claude` once to authenticate.
+- **python not found** when running the artisan wrapper — pass
+  `--python=py` or the full path:
+  `php artisan app:translator --python=C:/Python313/python.exe`.
+- **Writes reorder the whole JSON file** — not supposed to happen. The
+  script preserves the existing key order and only inserts new keys at their
+  alphabetical position. Round-trip is byte-identical on unchanged data.

--- a/tools/translator/ai.py
+++ b/tools/translator/ai.py
@@ -1,0 +1,259 @@
+"""
+Claude-powered translation suggestions for the SISC translator GUI.
+
+Uses the `claude` CLI (Claude Code) when available — no API key required,
+billing goes through each dev's existing Claude subscription.
+
+Defaults (keep usage cheap):
+  - Model: Haiku by default — plenty for short UI labels, ~10× cheaper than Sonnet.
+    Override with env `SISC_TRANSLATOR_MODEL` (values: 'haiku' | 'sonnet' | 'opus'
+    or a full Anthropic model id).
+  - Wider file context: OFF by default. Opt-in with env
+    `SISC_TRANSLATOR_WIDE_CONTEXT=1` to include ±20 lines around the usage line.
+    Off = immediate 5-line context only (smaller prompt, cheaper).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+# --------------------------------------------------------------------------- #
+# Detection
+# --------------------------------------------------------------------------- #
+
+def claude_cli_path() -> Optional[str]:
+    """Return the absolute path to the `claude` binary if available, else None."""
+    return shutil.which("claude")
+
+
+def is_available() -> bool:
+    return claude_cli_path() is not None
+
+
+# --------------------------------------------------------------------------- #
+# Prompt construction
+# --------------------------------------------------------------------------- #
+
+SYSTEM_PROMPT = """You translate UI labels for SISC, a Canadian Scout management platform (Laravel + Kompo framework). Audience: volunteer leaders and admin staff, mostly Quebec-based.
+
+GLOSSARY (strict — reuse these terms verbatim):
+- Scout = youth member (NEVER say "Member" / "Membre")
+- Volunteer / Bénévole = adult leader (NEVER say "Leader" / "Chef")
+- Person / Personne = individual record (NEVER "Member" / "Membre")
+- Branch / Branche, Unit / Unité, Group / Groupe, District = hierarchy levels
+- Camp (stays "Camp" in FR) = overnight camping event, approval workflow
+- Inscription / Inscription = registration/sign-up (keep "inscription" in FR)
+- Brevet / Brevet = training certificate (keep "brevet" in FR, not "diplôme")
+- Background check / Vérification des antécédents = judiciary record check
+- Meetup / Rencontre = weekly meeting
+- Fundraiser / Collecte de fonds
+
+STYLE:
+- Short, direct UI labels. Buttons/titles = 1-4 words. Error/help = full sentence ending with period.
+- EN: American spelling. Sentence case for labels ("Save changes"), Title Case only for page titles.
+- FR: Quebec conventions. No franglais. Use "courriel" (not "email"), "téléverser" (not "upload"), "magasiner" (not "shopper").
+- Preserve placeholders EXACTLY: `:attribute`, `:max`, `:user`, `{{name}}` — never translate them.
+- Match the formality shown in the code context.
+
+CLASSIFICATION — set is_translation_key=false when the identifier is clearly ONE of:
+- icon name (hyphenated token like chevron-down, alert-triangle, dollar-circle, star-1) or context shows _Sax/_Icon/icon(
+- date/time/number format (Y-m-d, H:i:s, M d, Y, #,##0.00)
+- HTTP/HTML attribute (X-*, aria-*, data-*, role=)
+- snake_case DB column or code identifier ending in _id, _at, _type, _by
+- ALL_CAPS constant (PDO_MYSQL, MEMORY_LIMIT)
+- single generic code word that never appears alone in UI (function_exists, pdo_mysql)
+Otherwise true.
+
+OUTPUT: JSON only. No fences, no prose, no commentary.
+{"is_translation_key":bool,"en":"...","fr":"..."}
+Examples:
+{"is_translation_key":true,"en":"Camp validation","fr":"Validation de camp"}
+{"is_translation_key":true,"en":"Add a volunteer","fr":"Ajouter un bénévole"}
+{"is_translation_key":false,"en":"chevron-down","fr":"chevron-down"}"""
+
+
+def build_user_prompt(
+    key: str,
+    code_context: str,
+    file_path: str = "",
+    wider_context: str = "",
+) -> str:
+    """Assemble the user-facing portion of the prompt."""
+    parts: list[str] = [f"Translation key: `{key}`", ""]
+
+    if file_path:
+        parts.append(f"Source file: {file_path}")
+    parts.append("")
+
+    if code_context:
+        parts += [
+            "Immediate code context where the key is used:",
+            "```php",
+            code_context.strip(),
+            "```",
+            "",
+        ]
+
+    if wider_context and wider_context.strip() != code_context.strip():
+        parts += [
+            "Wider file context (arrow marks the line of interest):",
+            "```php",
+            wider_context.rstrip(),
+            "```",
+            "",
+        ]
+
+    parts.append(
+        "Produce the English and French translations. "
+        "Reply with JSON only: {\"en\": \"...\", \"fr\": \"...\"}"
+    )
+    return "\n".join(parts)
+
+
+# --------------------------------------------------------------------------- #
+# File context extraction
+# --------------------------------------------------------------------------- #
+
+def read_wider_context(
+    project_root: Path,
+    file_rel: str,
+    line: Optional[int],
+    radius: int = 20,
+) -> str:
+    """Read a window of lines around `line` from the source file, with a `→` marker."""
+    if not file_rel or not line:
+        return ""
+    rel = file_rel.replace("\\", os.sep).replace("/", os.sep)
+    path = project_root / rel
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+    except (FileNotFoundError, OSError):
+        return ""
+
+    lines = source.splitlines()
+    start = max(0, line - radius - 1)
+    end = min(len(lines), line + radius)
+
+    out: list[str] = []
+    for i, text in enumerate(lines[start:end], start=start + 1):
+        marker = "→ " if i == line else "  "
+        out.append(f"{marker}{i:5d} | {text}")
+    return "\n".join(out)
+
+
+# --------------------------------------------------------------------------- #
+# Claude call
+# --------------------------------------------------------------------------- #
+
+class AiError(RuntimeError):
+    """Raised when the AI call fails or produces unparseable output."""
+
+
+def _extract_json(response: str) -> dict:
+    """Pull the first balanced JSON object out of a text response."""
+    text = response.strip()
+    if text.startswith("```"):
+        # Strip opening ``` and optional language hint
+        first_nl = text.find("\n")
+        if first_nl >= 0:
+            text = text[first_nl + 1:]
+        if text.endswith("```"):
+            text = text[:-3]
+        text = text.strip()
+
+    start = text.find("{")
+    end = text.rfind("}")
+    if start < 0 or end <= start:
+        raise AiError(f"No JSON object in response:\n{response!r}")
+    try:
+        return json.loads(text[start:end + 1])
+    except json.JSONDecodeError as exc:
+        raise AiError(f"Invalid JSON from AI: {exc}\nRaw: {text[start:end+1]!r}")
+
+
+_MODEL_ALIASES = {
+    "haiku": "claude-haiku-4-5-20251001",
+    "sonnet": "claude-sonnet-4-6",
+    "opus": "claude-opus-4-7",
+}
+
+
+def _resolve_model() -> str:
+    """Model to use for translations. Defaults to Haiku (cheap + fast)."""
+    raw = (os.environ.get("SISC_TRANSLATOR_MODEL") or "haiku").strip()
+    return _MODEL_ALIASES.get(raw.lower(), raw)
+
+
+def suggest(
+    key: str,
+    code_context: str,
+    file_path: str = "",
+    wider_context: str = "",
+    timeout: int = 60,
+) -> dict:
+    """
+    Ask Claude for EN/FR translations for `key`.
+
+    Returns a dict with 'en', 'fr', 'is_translation_key'. Raises AiError on failure.
+
+    Cost-saving defaults:
+    - Model defaults to Haiku (override with env SISC_TRANSLATOR_MODEL).
+    - wider_context is dropped unless env SISC_TRANSLATOR_WIDE_CONTEXT=1 — the
+      immediate 5-line snippet captured by the analyzer is usually enough for
+      short UI labels and makes each prompt dramatically smaller.
+    """
+    cli = claude_cli_path()
+    if not cli:
+        raise AiError("`claude` CLI not found on PATH. Install Claude Code and authenticate.")
+
+    include_wide = os.environ.get("SISC_TRANSLATOR_WIDE_CONTEXT", "").strip() in ("1", "true", "yes")
+    effective_wider = wider_context if include_wide else ""
+
+    prompt = (
+        SYSTEM_PROMPT
+        + "\n\n---\n\n"
+        + build_user_prompt(key, code_context, file_path, effective_wider)
+    )
+
+    creationflags = 0
+    if os.name == "nt":
+        creationflags = 0x08000000  # CREATE_NO_WINDOW — no console flash
+
+    cmd = [cli, "--print", "--model", _resolve_model()]
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            creationflags=creationflags,
+        )
+    except FileNotFoundError as exc:
+        raise AiError(f"claude CLI not launchable: {exc}")
+    except subprocess.TimeoutExpired:
+        raise AiError(f"claude CLI timed out after {timeout}s")
+
+    if proc.returncode != 0:
+        raise AiError(
+            f"claude exited {proc.returncode}: "
+            f"{(proc.stderr or proc.stdout).strip()[:300]}"
+        )
+
+    data = _extract_json(proc.stdout)
+    if "en" not in data or "fr" not in data:
+        raise AiError(f"Response missing 'en' or 'fr' key: {data!r}")
+    return {
+        "en": str(data["en"]).strip(),
+        "fr": str(data["fr"]).strip(),
+        "is_translation_key": bool(data.get("is_translation_key", True)),
+    }

--- a/tools/translator/translator.py
+++ b/tools/translator/translator.py
@@ -1,0 +1,1407 @@
+#!/usr/bin/env python3
+"""
+SISC Translation Helper — desktop GUI to translate missing keys one by one.
+
+Usage:
+    python translator.py                    # runs the artisan analyzer itself
+    python translator.py missing.json       # uses an existing JSON export
+    python translator.py --project PATH     # force project root detection
+
+No external deps — tkinter + stdlib only. Tested on Windows with Python 3.10+.
+
+Workflow:
+    1. Launch. The UI loads the list of missing keys (EN/FR merged).
+    2. Navigate with [<] [>] or arrow keys. For each key:
+       - Read the context snippet (file path + code around the usage).
+       - Fill in the English and French translations.
+       - [Save & Next] writes both locales to resources/lang/*.json and advances.
+       - [Skip] moves to the next key without writing.
+       - [Ignore] records the key in storage/app/translation_ignore_pending.json
+         so you can later run `php artisan app:missing-translation-analyzer-command
+         --exclude-key=...` to persist it.
+    3. Close the window when done. Rerun the artisan analyzer to refresh.
+
+Limitations (v1):
+    - Does not update the `missing_translations` table directly (use DB clear or
+      the UI table to mark rows as fixed after saving).
+    - Does not sync to BabelEdit `.babel` files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+import tkinter as tk
+from datetime import datetime
+from pathlib import Path
+from tkinter import filedialog, messagebox, scrolledtext, ttk
+from typing import Optional
+
+# Local module — sibling file.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import ai as ai_module  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Paths & project discovery
+# --------------------------------------------------------------------------- #
+
+def find_project_root(start: Path) -> Optional[Path]:
+    """Walk up from `start` until a Laravel app root is found.
+
+    Required markers: `artisan` binary + `composer.json` + `resources/lang/`.
+    The `artisan` check is what distinguishes the real app root from a package
+    (e.g. vendor/condoedge/utils ships a composer.json + resources/lang/ too).
+    """
+    for parent in [start, *start.parents]:
+        if (
+            (parent / "artisan").is_file()
+            and (parent / "composer.json").is_file()
+            and (parent / "resources" / "lang").is_dir()
+        ):
+            return parent
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Lang file I/O (preserves tab indent + alphabetical key order)
+# --------------------------------------------------------------------------- #
+
+def load_lang(path: Path) -> dict:
+    """Load a Laravel flat-JSON lang file, preserving insertion order."""
+    if not path.is_file():
+        return {}
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)  # dict preserves insertion order (Python 3.7+)
+
+
+def _insert_sorted(ordered_items: list[tuple[str, str]], new_key: str, new_value: str) -> list[tuple[str, str]]:
+    """Insert a new (key, value) into the ordered list at a lexicographic position,
+    case-insensitive. Existing order is otherwise preserved so diffs stay minimal."""
+    lower = new_key.lower()
+    for i, (k, _v) in enumerate(ordered_items):
+        if lower < k.lower():
+            return ordered_items[:i] + [(new_key, new_value)] + ordered_items[i:]
+    return ordered_items + [(new_key, new_value)]
+
+
+def save_lang(path: Path, data: dict, original: dict) -> None:
+    """Write the lang file preserving the file's existing key order and only
+    inserting new keys at their case-insensitive alphabetical position."""
+    # Start from the original order, carrying over updated values.
+    ordered: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for k in original.keys():
+        if k in data:
+            ordered.append((k, data[k]))
+            seen.add(k)
+
+    # Add new keys (those not in the original file) at their sorted position.
+    for k in data.keys():
+        if k not in seen:
+            ordered = _insert_sorted(ordered, k, data[k])
+
+    body = json.dumps(dict(ordered), ensure_ascii=False, indent="\t")
+    # Laravel lang JSON convention: trailing newline, LF line endings.
+    with path.open("w", encoding="utf-8", newline="\n") as fh:
+        fh.write(body + "\n")
+
+
+# --------------------------------------------------------------------------- #
+# Analyzer integration
+# --------------------------------------------------------------------------- #
+
+def run_analyzer(project_root: Path) -> dict:
+    """Invoke `php artisan app:missing-translation-analyzer-command --json` and
+    return the parsed payload (dict with locale keys)."""
+    proc = subprocess.run(
+        ["php", "artisan", "app:missing-translation-analyzer-command", "--json"],
+        cwd=str(project_root),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"artisan exited {proc.returncode}\nstderr: {proc.stderr}"
+        )
+    # First line is "Indexing N translation keys..." — strip until '{' or '['.
+    stdout = proc.stdout
+    brace = stdout.find("{")
+    if brace < 0:
+        raise RuntimeError(f"No JSON object in analyzer output:\n{stdout[:500]}")
+    return json.loads(stdout[brace:])
+
+
+def load_missing_payload(
+    json_file: Optional[Path], project_root: Path
+) -> dict:
+    if json_file is not None:
+        if not json_file.is_file():
+            raise SystemExit(f"{json_file} not found")
+        text = json_file.read_text(encoding="utf-8")
+        brace = text.find("{")
+        if brace < 0:
+            raise SystemExit("No JSON object found in input file")
+        return json.loads(text[brace:])
+    return run_analyzer(project_root)
+
+
+# --------------------------------------------------------------------------- #
+# Model: merge locales into a single iterable of entries
+# --------------------------------------------------------------------------- #
+
+def build_entries(payload: dict) -> list[dict]:
+    """
+    Collapse the per-locale payload into a flat, deduplicated list of keys.
+    Keeps ALL locations so target resolution can prefer linked-folder paths
+    when multiple files reference the same key.
+    """
+    by_key: dict[str, dict] = {}
+    for locale, items in payload.items():
+        for item in items:
+            key = item["key"]
+            locations = item.get("locations") or []
+            if key not in by_key:
+                primary = locations[0] if locations else {}
+                by_key[key] = {
+                    "key": key,
+                    "file": primary.get("file", ""),
+                    "line": primary.get("line"),
+                    "context": primary.get("context", ""),
+                    "all_files": [loc.get("file", "") for loc in locations if loc.get("file")],
+                }
+            else:
+                # Merge additional locations from subsequent locales.
+                existing_files = set(by_key[key]["all_files"])
+                for loc in locations:
+                    f = loc.get("file")
+                    if f and f not in existing_files:
+                        by_key[key]["all_files"].append(f)
+                        existing_files.add(f)
+    return sorted(by_key.values(), key=lambda e: e["key"].lower())
+
+
+# --------------------------------------------------------------------------- #
+# UI
+# --------------------------------------------------------------------------- #
+
+class TranslatorApp(tk.Tk):
+    PADDING = 8
+
+    def __init__(self, entries: list[dict], project_root: Path):
+        super().__init__()
+        self.title(f"SISC Translation Helper — {len(entries)} missing")
+        self.geometry("820x620")
+        self.minsize(700, 520)
+        self.configure(padx=self.PADDING, pady=self.PADDING)
+
+        self.entries = entries
+        self.index = 0
+        self.project_root = project_root
+        # Per-target lang cache. A "target" is a project root (main app OR a linked package
+        # that owns its own resources/lang). Each target gets its own lang dict + snapshot.
+        self._lang_cache: dict[Path, dict] = {}
+        # Precompute for the main app so legacy accessors (en_data/fr_data) still work.
+        self._ensure_target_loaded(project_root)
+        main = self._lang_cache[project_root]
+        self.en_path = main["en_path"]
+        self.fr_path = main["fr_path"]
+        self.en_data = main["en"]
+        self.fr_data = main["fr"]
+        self.en_original = main["en_original"]
+        self.fr_original = main["fr_original"]
+        self.ignore_path = project_root / "storage" / "app" / "translation_ignore_pending.json"
+        self.ignored: set[str] = self._load_ignored()
+        # Buffer of artisan subprocesses running fire-and-forget — kept to avoid GC killing them.
+        self._async_procs: list[subprocess.Popen] = []
+        # Session counters
+        self._session = {"saved": 0, "ignored": 0, "skipped": 0}
+        # Per-entry drafts: unsaved text typed in EN/FR fields as the user navigates.
+        # Flushed to disk on Save & Close.
+        self._drafts: dict[str, dict[str, str]] = {}
+        # AI suggestion cache: key -> {'en', 'fr', 'is_translation_key'}
+        self._ai_cache: dict[str, dict] = {}
+        # Auto-prefetch state
+        self._auto_var: Optional[tk.BooleanVar] = None
+        self._prefetch_stop = threading.Event()
+        self._prefetch_thread: Optional[threading.Thread] = None
+        # Auto save & next state
+        self._auto_advance_var: Optional[tk.BooleanVar] = None
+        self._auto_advance_after_id: Optional[str] = None
+        self._auto_advance_countdown_id: Optional[str] = None
+        self._auto_advance_seconds = 3  # base delay
+        # Pending action for the current countdown: 'save' | 'ignore' | 'skip'
+        self._auto_advance_action: Optional[str] = None
+
+        self._build_ui()
+        self._bind_shortcuts()
+        if entries:
+            self.render_current()
+        else:
+            self._show_empty_state()
+
+    # ---- data -------------------------------------------------------------
+    def _load_ignored(self) -> set[str]:
+        if self.ignore_path.is_file():
+            try:
+                return set(json.loads(self.ignore_path.read_text(encoding="utf-8")))
+            except Exception:
+                pass
+        return set()
+
+    def _persist_ignored(self) -> None:
+        self.ignore_path.parent.mkdir(parents=True, exist_ok=True)
+        self.ignore_path.write_text(
+            json.dumps(sorted(self.ignored), ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    # ---- layout -----------------------------------------------------------
+    def _build_ui(self) -> None:
+        header = ttk.Frame(self)
+        header.pack(fill="x")
+        self.progress_label = ttk.Label(header, text="", font=("Segoe UI", 10, "bold"))
+        self.progress_label.pack(side="left")
+        self.progress_bar = ttk.Progressbar(header, mode="determinate", length=260)
+        self.progress_bar.pack(side="right")
+
+        key_frame = ttk.LabelFrame(self, text="Translation key")
+        key_frame.pack(fill="x", pady=(self.PADDING, 0))
+        self.key_label = ttk.Label(key_frame, text="", font=("Consolas", 11, "bold"))
+        self.key_label.pack(side="left", padx=6, pady=6)
+
+        loc_frame = ttk.LabelFrame(self, text="Found in")
+        loc_frame.pack(fill="x", pady=(self.PADDING, 0))
+        self.file_label = ttk.Label(loc_frame, text="", font=("Consolas", 9), foreground="#0066cc", cursor="hand2")
+        self.file_label.pack(side="left", padx=6, pady=4)
+        self.file_label.bind("<Button-1>", lambda _e: self._open_file_in_editor())
+
+        ctx_frame = ttk.LabelFrame(self, text="Code context")
+        ctx_frame.pack(fill="both", expand=False, pady=(self.PADDING, 0))
+        self.context_text = scrolledtext.ScrolledText(ctx_frame, height=6, wrap="none", font=("Consolas", 9))
+        self.context_text.pack(fill="both", expand=True, padx=4, pady=4)
+        self.context_text.configure(state="disabled")
+
+        # AI suggest bar
+        ai_bar = ttk.Frame(self)
+        ai_bar.pack(fill="x", pady=(self.PADDING, 0))
+        ai_ready = ai_module.is_available()
+        self.suggest_btn = ttk.Button(
+            ai_bar,
+            text="🤖 Suggest translations" if ai_ready else "🤖 Suggest (claude CLI not found)",
+            command=self.suggest_ai,
+        )
+        self.suggest_btn.pack(side="left")
+        if not ai_ready:
+            self.suggest_btn.configure(state="disabled")
+
+        self._auto_var = tk.BooleanVar(value=False)
+        self.auto_check = ttk.Checkbutton(
+            ai_bar,
+            text="Auto-prefetch next keys",
+            variable=self._auto_var,
+            command=self._on_auto_toggle,
+        )
+        self.auto_check.pack(side="left", padx=(12, 0))
+        if not ai_ready:
+            self.auto_check.configure(state="disabled")
+
+        self._auto_advance_var = tk.BooleanVar(value=False)
+        self.auto_advance_check = ttk.Checkbutton(
+            ai_bar,
+            text=f"Auto save & next ({self._auto_advance_seconds}s)",
+            variable=self._auto_advance_var,
+            command=self._on_auto_advance_toggle,
+        )
+        self.auto_advance_check.pack(side="left", padx=(12, 0))
+        if not ai_ready:
+            self.auto_advance_check.configure(state="disabled")
+
+        self.ai_status = ttk.Label(ai_bar, text="", font=("Segoe UI", 9), foreground="#6366f1")
+        self.ai_status.pack(side="left", padx=(10, 0))
+
+        ttk.Button(
+            ai_bar,
+            text="🔗 Linked packages…",
+            command=self.manage_linked_packages,
+        ).pack(side="right")
+
+        self.target_label = ttk.Label(
+            self, text="", font=("Segoe UI", 9), foreground="#0f766e"
+        )
+        self.target_label.pack(fill="x", pady=(self.PADDING, 0))
+
+        self.en_frame = ttk.LabelFrame(self, text="English")
+        self.en_frame.pack(fill="x", pady=(self.PADDING, 0))
+        self.en_var = tk.StringVar()
+        self.en_entry = ttk.Entry(self.en_frame, textvariable=self.en_var, font=("Segoe UI", 10))
+        self.en_entry.pack(fill="x", padx=6, pady=6)
+
+        self.fr_frame = ttk.LabelFrame(self, text="Français")
+        self.fr_frame.pack(fill="x", pady=(self.PADDING, 0))
+        self.fr_var = tk.StringVar()
+        self.fr_entry = ttk.Entry(self.fr_frame, textvariable=self.fr_var, font=("Segoe UI", 10))
+        self.fr_entry.pack(fill="x", padx=6, pady=6)
+
+        # Cancel the auto save-and-next countdown as soon as the user touches either field.
+        # Ignore programmatic writes from `render_current` — we detect that via a flag set
+        # around those writes. For simplicity here we just cancel any pending countdown;
+        # render_current re-arms it immediately after so nothing visible changes.
+        self._user_typing_suspend = False
+
+        def _on_field_change(*_a):
+            if not self._user_typing_suspend:
+                self._cancel_auto_advance("Countdown cancelled (edit detected)")
+
+        self.en_var.trace_add("write", _on_field_change)
+        self.fr_var.trace_add("write", _on_field_change)
+
+        btns = ttk.Frame(self)
+        btns.pack(fill="x", pady=(self.PADDING, 0))
+        self.prev_btn = ttk.Button(btns, text="◀ Prev", command=self.prev)
+        self.prev_btn.pack(side="left")
+        ttk.Button(btns, text="Skip", command=self.skip).pack(side="left", padx=(6, 0))
+        self.ignore_btn = ttk.Button(btns, text="Ignore", command=self.ignore)
+        self.ignore_btn.pack(side="left", padx=(6, 0))
+        self.save_close_btn = ttk.Button(btns, text="Save && Close", command=self.save_and_close)
+        self.save_close_btn.pack(side="right", padx=(6, 0))
+        self.save_btn = ttk.Button(btns, text="Save && Next", command=self.save_and_next)
+        self.save_btn.pack(side="right")
+        ttk.Button(btns, text="Next ▶", command=self.next).pack(side="right", padx=(0, 6))
+
+        # Toast area: auto-dismissing coloured banner for Save/Ignore confirmations.
+        self.toast = tk.Label(
+            self, text="", font=("Segoe UI", 10, "bold"),
+            anchor="w", padx=12, pady=6,
+            background=self.cget("background"),
+            foreground=self.cget("background"),  # invisible when idle
+        )
+        self.toast.pack(fill="x", pady=(self.PADDING, 0))
+        self._toast_after_id: Optional[str] = None
+
+        self.status_label = ttk.Label(self, text="", font=("Segoe UI", 9))
+        self.status_label.pack(fill="x")
+
+        # Footer: session counters + live mtime of the lang files (proof they're being updated).
+        footer = ttk.Frame(self)
+        footer.pack(fill="x", pady=(6, 0))
+        self.session_label = ttk.Label(footer, text="", font=("Segoe UI", 9), foreground="#334155")
+        self.session_label.pack(side="left")
+        self.files_label = ttk.Label(footer, text="", font=("Consolas", 8), foreground="#64748b")
+        self.files_label.pack(side="right")
+        self._refresh_footer()
+
+    def _bind_shortcuts(self) -> None:
+        self.bind("<Left>", lambda _e: self.prev())
+        self.bind("<Right>", lambda _e: self.next())
+        self.bind("<Control-s>", lambda _e: self.save_and_next())
+        self.bind("<Control-S>", lambda _e: self.save_and_next())
+        self.bind("<Control-g>", lambda _e: self.suggest_ai())
+        self.bind("<Control-G>", lambda _e: self.suggest_ai())
+        self.bind("<Escape>", lambda _e: self.destroy())
+
+    def _show_empty_state(self) -> None:
+        self.key_label.configure(text="No missing translations — you're done! 🎉")
+        self.file_label.configure(text="")
+        self.context_text.configure(state="normal")
+        self.context_text.delete("1.0", "end")
+        self.context_text.configure(state="disabled")
+        self.en_entry.configure(state="disabled")
+        self.fr_entry.configure(state="disabled")
+        self.prev_btn.configure(state="disabled")
+        self.save_btn.configure(state="disabled")
+        self.progress_label.configure(text="0 / 0")
+
+    # ---- Link-required guard ---------------------------------------------
+    def _show_link_required_dialog(self, vendor_pkgs: list[str]) -> None:
+        """Alert the user that the key lives only in vendor/ and must be linked."""
+        pkg_lines = "\n".join(f"  • {p}" for p in vendor_pkgs)
+        example_add = vendor_pkgs[0] if vendor_pkgs else "vendor/package"
+        messagebox.showwarning(
+            "Link the package first",
+            "This translation key only appears inside vendor packages:\n\n"
+            f"{pkg_lines}\n\n"
+            "Saving into the main project's lang files would pollute them with "
+            "translations that belong to the package.\n\n"
+            "Please link your local clone of the package:\n"
+            "  • Click '🔗 Linked packages…' in the toolbar, or\n"
+            f"  • Run: php artisan app:translator-packages add C:/path/to/{example_add}\n\n"
+            "Then click Rescan to pick up the link and retry the save."
+        )
+
+    # ---- target project resolution ---------------------------------------
+    def _ensure_target_loaded(self, target: Path) -> None:
+        """Load (once, cached) the en/fr JSON for a given project root."""
+        target = target.resolve()
+        if target in self._lang_cache:
+            return
+        en_path = target / "resources" / "lang" / "en.json"
+        fr_path = target / "resources" / "lang" / "fr.json"
+        en_data = load_lang(en_path)
+        fr_data = load_lang(fr_path)
+        self._lang_cache[target] = {
+            "en_path": en_path,
+            "fr_path": fr_path,
+            "en": en_data,
+            "fr": fr_data,
+            "en_original": dict(en_data),
+            "fr_original": dict(fr_data),
+        }
+
+    def _resolve_target_project(self, entry: dict) -> Path:
+        """Pick the project whose lang files should receive this entry's translation.
+
+        Rule: if ANY of the key's source locations lives inside a user-linked
+        package that has its own `resources/lang/`, write there (linked folders
+        win over vendor/app). Otherwise fall back to the main app.
+
+        Real vendor/ packages (condoedge/*, kompo/*) are ignored — writing to
+        vendor/ would be overwritten by the next composer install.
+        """
+        candidate_files: list[str] = []
+        if entry.get("all_files"):
+            candidate_files.extend(entry["all_files"])
+        elif entry.get("file"):
+            candidate_files.append(entry["file"])
+
+        if not candidate_files:
+            return self.project_root
+
+        linked_abs_paths: list[Path] = []
+        for linked_str in self._load_linked_packages():
+            try:
+                p = Path(linked_str).resolve()
+                if (p / "resources" / "lang").is_dir():
+                    linked_abs_paths.append(p)
+            except Exception:
+                continue
+
+        if not linked_abs_paths:
+            return self.project_root
+
+        for file_rel in candidate_files:
+            rel = file_rel.replace("\\", os.sep).replace("/", os.sep)
+            file_abs = Path(rel)
+            if not file_abs.is_absolute():
+                file_abs = (self.project_root / rel).resolve()
+            else:
+                file_abs = file_abs.resolve()
+
+            for linked_abs in linked_abs_paths:
+                try:
+                    file_abs.relative_to(linked_abs)
+                    return linked_abs
+                except ValueError:
+                    continue
+
+        return self.project_root
+
+    def _entry_only_in_vendor(self, entry: dict) -> list[str]:
+        """Return the list of vendor/<vendor>/<package> names that contain this key
+        when NO location in the main app (non-vendor) exists.
+
+        An empty list means at least one location is in the main app — safe to write
+        to the project's own lang files.
+        """
+        files = entry.get("all_files") or ([entry["file"]] if entry.get("file") else [])
+        if not files:
+            return []
+
+        vendor_packages: set[str] = set()
+        for raw in files:
+            rel = raw.replace("\\", "/")
+            idx = rel.find("vendor/")
+            if idx < 0 or (idx > 0 and rel[idx - 1] not in ("", "/", ":")):
+                # Not under a vendor/ path → main-app location exists.
+                return []
+            pieces = rel[idx + len("vendor/"):].split("/", 2)
+            if len(pieces) >= 2:
+                vendor_packages.add(f"{pieces[0]}/{pieces[1]}")
+
+        return sorted(vendor_packages)
+
+    def _target_label(self, target: Path) -> str:
+        """Human-friendly display of where a save will land."""
+        try:
+            rel = target.relative_to(self.project_root)
+            if str(rel) == ".":
+                return "main project"
+            return f"linked: {rel}"
+        except ValueError:
+            return f"linked: {target.name}"
+
+    # ---- rendering --------------------------------------------------------
+    def _capture_draft_if_dirty(self) -> None:
+        """If the current EN/FR fields differ from the persisted values (in the
+        entry's target project), stash them so navigating away doesn't lose text."""
+        if not self.entries:
+            return
+        entry = self.entries[self.index]
+        key = entry["key"]
+        target = self._resolve_target_project(entry)
+        self._ensure_target_loaded(target)
+        store = self._lang_cache[target]
+
+        en = self.en_var.get().strip()
+        fr = self.fr_var.get().strip()
+        saved_en = store["en"].get(key, "").strip()
+        saved_fr = store["fr"].get(key, "").strip()
+        if en != saved_en or fr != saved_fr:
+            self._drafts[key] = {"en": en, "fr": fr, "target": str(target)}
+        else:
+            self._drafts.pop(key, None)
+
+    def render_current(self) -> None:
+        if not self.entries:
+            self._show_empty_state()
+            return
+
+        entry = self.entries[self.index]
+        key = entry["key"]
+        self.key_label.configure(text=key)
+
+        loc_txt = entry["file"]
+        if entry.get("line"):
+            loc_txt = f"{loc_txt}:{entry['line']}"
+        self.file_label.configure(text=loc_txt or "(no location)")
+
+        self.context_text.configure(state="normal")
+        self.context_text.delete("1.0", "end")
+        self.context_text.insert("1.0", entry.get("context", ""))
+        self.context_text.configure(state="disabled")
+
+        # Resolve which project owns this key, load its lang data if not yet cached.
+        target = self._resolve_target_project(entry)
+        self._ensure_target_loaded(target)
+        store = self._lang_cache[target]
+
+        # Display the resolved target — flag vendor-only keys that need linking.
+        vendor_pkgs = (
+            self._entry_only_in_vendor(entry) if target == self.project_root else []
+        )
+        if vendor_pkgs:
+            self.target_label.configure(
+                text=f"⚠ Link required — key only in: {', '.join(vendor_pkgs)}",
+                foreground="#b45309",
+            )
+        else:
+            self.target_label.configure(
+                text=f"Will write to: {self._target_label(target)}",
+                foreground="#0f766e",
+            )
+
+        # Priority: unsaved draft > AI cache > already-saved JSON value > empty
+        draft = self._drafts.get(key)
+        cached = self._ai_cache.get(key)
+        self._user_typing_suspend = True
+        try:
+            if draft:
+                self.en_var.set(draft["en"])
+                self.fr_var.set(draft["fr"])
+            elif cached:
+                self.en_var.set(cached.get("en", ""))
+                self.fr_var.set(cached.get("fr", ""))
+                self.ai_status.configure(text="🤖 Prefilled from cache — review before saving")
+            else:
+                self.en_var.set(store["en"].get(key, ""))
+                self.fr_var.set(store["fr"].get(key, ""))
+                self.ai_status.configure(text="")
+        finally:
+            self._user_typing_suspend = False
+
+        # Classify → maybe highlight Ignore
+        if cached and cached.get("is_translation_key") is False:
+            self._highlight_ignore_suggestion()
+        else:
+            self._reset_ignore_highlight()
+
+        total = len(self.entries)
+        self.progress_label.configure(text=f"Key {self.index + 1} / {total}")
+        pct = ((self.index + 1) / total) * 100 if total else 0
+        self.progress_bar["value"] = pct
+
+        self.prev_btn.configure(state="normal" if self.index > 0 else "disabled")
+
+        self.en_entry.focus_set()
+        self.en_entry.icursor("end")
+        self.status_label.configure(text="")
+
+        # Possibly start the auto save-and-next countdown.
+        self._maybe_start_auto_advance()
+
+    # ---- actions ----------------------------------------------------------
+    def _do_save(self) -> Optional[list[str]]:
+        """Write the current entry's EN/FR values to the RESOLVED target project.
+        Returns the list of saved locales (e.g. ['EN', 'FR']) or None on error."""
+        entry = self.entries[self.index]
+        en = self.en_var.get().strip()
+        fr = self.fr_var.get().strip()
+
+        if not en and not fr:
+            messagebox.showwarning(
+                "Empty",
+                "Both fields are empty — use Skip if you want to move on without saving.",
+            )
+            return None
+
+        target = self._resolve_target_project(entry)
+
+        # Guard: if the resolved target is the main project but the key ONLY lives
+        # in vendor packages, block the save — writing to main would pollute it with
+        # translations that belong to the package.
+        if target == self.project_root:
+            vendor_pkgs = self._entry_only_in_vendor(entry)
+            if vendor_pkgs:
+                self._show_link_required_dialog(vendor_pkgs)
+                return None
+
+        self._ensure_target_loaded(target)
+        store = self._lang_cache[target]
+
+        if en:
+            store["en"][entry["key"]] = en
+        if fr:
+            store["fr"][entry["key"]] = fr
+
+        try:
+            save_lang(store["en_path"], store["en"], store["en_original"])
+            save_lang(store["fr_path"], store["fr"], store["fr_original"])
+        except Exception as exc:
+            messagebox.showerror("Save error", str(exc))
+            return None
+
+        saved = []
+        if en:
+            saved.append("EN")
+        if fr:
+            saved.append("FR")
+
+        # Mark matching DB rows as fixed — async so the UI doesn't block.
+        self._mark_db_async(entry["key"], "fixed", [loc.lower() for loc in saved])
+        self._session["saved"] += 1
+        self._refresh_footer()
+        return saved
+
+    def save_and_next(self) -> None:
+        entry = self.entries[self.index]
+        saved = self._do_save()
+        if saved is None:
+            return
+
+        self._show_toast(
+            f"✓ Saved  [{'+'.join(saved)}]  {entry['key']}  →  en.json + fr.json",
+            bg="#16a34a",
+        )
+        self.status_label.configure(
+            text=f"Saved [{'+'.join(saved)}] for {entry['key']} · DB updated · files on disk"
+        )
+        self.next()
+
+    def suggest_ai(self) -> None:
+        """Fire a Claude request in a background thread; populate fields when done."""
+        if not self.entries:
+            return
+        if not ai_module.is_available():
+            messagebox.showinfo("Not available", "The `claude` CLI was not found on PATH.\nInstall Claude Code and authenticate, then relaunch.")
+            return
+
+        entry = self.entries[self.index]
+        self.suggest_btn.configure(state="disabled", text="🤖 Asking Claude…")
+        self.ai_status.configure(text="Waiting for response (file context included)…")
+        self.update_idletasks()
+
+        wider = ai_module.read_wider_context(
+            self.project_root,
+            entry.get("file", ""),
+            entry.get("line"),
+            radius=20,
+        )
+
+        def worker() -> None:
+            try:
+                result = ai_module.suggest(
+                    key=entry["key"],
+                    code_context=entry.get("context", ""),
+                    file_path=entry.get("file", ""),
+                    wider_context=wider,
+                    timeout=90,
+                )
+                self.after(0, self._on_ai_result, entry["key"], result)
+            except Exception as exc:  # AiError or subprocess issue
+                self.after(0, self._on_ai_error, str(exc))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _on_ai_result(self, key: str, result: dict) -> None:
+        """Called on the Tk main thread when the AI worker finishes."""
+        # Always cache the result regardless of navigation.
+        self._ai_cache[key] = result
+        self._reset_suggest_button()
+
+        # If the user navigated away, don't clobber their current fields.
+        if not self.entries or self.entries[self.index]["key"] != key:
+            return
+
+        en = result.get("en", "").strip()
+        fr = result.get("fr", "").strip()
+        self._user_typing_suspend = True
+        try:
+            if en:
+                self.en_var.set(en)
+            if fr:
+                self.fr_var.set(fr)
+        finally:
+            self._user_typing_suspend = False
+
+        if result.get("is_translation_key") is False:
+            self._highlight_ignore_suggestion()
+        else:
+            self._reset_ignore_highlight()
+            self._show_toast(f"🤖 Suggestion loaded for {key}", bg="#6366f1")
+            self.ai_status.configure(text="Suggestion loaded — review then Save")
+            # On-demand suggestion may also trigger the auto-advance countdown.
+            self._maybe_start_auto_advance()
+
+    def _on_ai_error(self, message: str) -> None:
+        self.ai_status.configure(text="")
+        self._reset_suggest_button()
+        self._show_toast("🤖 AI error — see dialog", bg="#dc2626")
+        messagebox.showerror("AI error", message)
+
+    def _reset_suggest_button(self) -> None:
+        self.suggest_btn.configure(state="normal", text="🤖 Suggest translations")
+
+    # ---- Linked packages manager ----
+    @property
+    def _linked_packages_path(self) -> Path:
+        return self.project_root / "storage" / "app" / "translator_linked_packages.json"
+
+    def _load_linked_packages(self) -> list[str]:
+        path = self._linked_packages_path
+        if path.is_file():
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(data, list):
+                    return [str(p) for p in data if isinstance(p, str) and p.strip()]
+            except Exception:
+                pass
+        return []
+
+    def _save_linked_packages(self, paths: list[str]) -> None:
+        path = self._linked_packages_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Deduplicate while preserving order.
+        seen, ordered = set(), []
+        for p in paths:
+            if p not in seen:
+                ordered.append(p)
+                seen.add(p)
+        path.write_text(
+            json.dumps(ordered, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    def manage_linked_packages(self) -> None:
+        win = tk.Toplevel(self)
+        win.title("Linked packages — scanned for translation keys")
+        win.geometry("640x380")
+        win.transient(self)
+        win.grab_set()
+
+        info = ttk.Label(
+            win,
+            text=(
+                "Folders listed below are scanned alongside app/, resources/, and\n"
+                "vendor/condoedge/* / vendor/kompo/*. Useful for local in-dev packages."
+            ),
+            font=("Segoe UI", 9),
+            foreground="#475569",
+            justify="left",
+        )
+        info.pack(fill="x", padx=10, pady=(10, 4))
+
+        list_frame = ttk.LabelFrame(win, text="Currently linked")
+        list_frame.pack(fill="both", expand=True, padx=10, pady=(0, 8))
+
+        listbox = tk.Listbox(list_frame, font=("Consolas", 9), activestyle="none")
+        listbox.pack(side="left", fill="both", expand=True, padx=6, pady=6)
+        sb = ttk.Scrollbar(list_frame, orient="vertical", command=listbox.yview)
+        sb.pack(side="right", fill="y")
+        listbox.configure(yscrollcommand=sb.set)
+
+        def refresh() -> None:
+            listbox.delete(0, "end")
+            for p in self._load_linked_packages():
+                exists = Path(p).is_dir()
+                marker = "  " if exists else "✗ "
+                listbox.insert("end", f"{marker}{p}")
+
+        def add_path() -> None:
+            chosen = filedialog.askdirectory(
+                parent=win,
+                title="Pick a local package folder to scan",
+                mustexist=True,
+            )
+            if not chosen:
+                return
+            chosen_abs = str(Path(chosen).resolve())
+            current = self._load_linked_packages()
+            if chosen_abs in current:
+                messagebox.showinfo("Already linked", f"{chosen_abs}\nis already in the list.")
+                return
+            current.append(chosen_abs)
+            self._save_linked_packages(current)
+            refresh()
+
+        def remove_selected() -> None:
+            sel = listbox.curselection()
+            if not sel:
+                return
+            current = self._load_linked_packages()
+            displayed = [current[i] for i in range(len(current))]
+            victims = {displayed[i] for i in sel if i < len(displayed)}
+            new_list = [p for p in current if p not in victims]
+            self._save_linked_packages(new_list)
+            refresh()
+
+        def clear_all() -> None:
+            if not self._load_linked_packages():
+                return
+            if messagebox.askyesno("Clear all", "Remove all linked packages?"):
+                self._save_linked_packages([])
+                refresh()
+
+        def close_and_maybe_rescan() -> None:
+            win.grab_release()
+            win.destroy()
+            if messagebox.askyesno(
+                "Rescan now?",
+                "Re-run the analyzer to pick up your linked packages? (~20 s)",
+            ):
+                self._rescan()
+
+        btns = ttk.Frame(win)
+        btns.pack(fill="x", padx=10, pady=(0, 10))
+        ttk.Button(btns, text="➕ Add folder…", command=add_path).pack(side="left")
+        ttk.Button(btns, text="✖ Remove", command=remove_selected).pack(side="left", padx=(6, 0))
+        ttk.Button(btns, text="Clear all", command=clear_all).pack(side="left", padx=(6, 0))
+        ttk.Button(btns, text="Done", command=close_and_maybe_rescan).pack(side="right")
+
+        refresh()
+
+    def _rescan(self) -> None:
+        """Re-run the analyzer and reload the missing-keys list in place."""
+        self._stop_prefetch()
+        self.ai_status.configure(text="Rescanning project (~20 s)…")
+        self.update_idletasks()
+
+        def worker() -> None:
+            try:
+                payload = run_analyzer(self.project_root)
+                self.after(0, self._on_rescan_done, payload, None)
+            except Exception as exc:
+                self.after(0, self._on_rescan_done, None, str(exc))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _on_rescan_done(self, payload: Optional[dict], error: Optional[str]) -> None:
+        if error:
+            self._show_toast(f"Rescan failed: {error[:60]}", bg="#dc2626")
+            self.ai_status.configure(text="")
+            messagebox.showerror("Rescan error", error)
+            return
+
+        self.entries = build_entries(payload or {})
+        # Drop AI cache entries for keys that no longer exist.
+        keep_keys = {e["key"] for e in self.entries}
+        self._ai_cache = {k: v for k, v in self._ai_cache.items() if k in keep_keys}
+        self._drafts = {k: v for k, v in self._drafts.items() if k in keep_keys}
+
+        if not self.entries:
+            self._show_empty_state()
+            self._show_toast("✓ Rescan complete — no missing keys 🎉", bg="#16a34a")
+            return
+
+        # Keep index in bounds.
+        self.index = min(self.index, len(self.entries) - 1)
+        self.title(f"SISC Translation Helper — {len(self.entries)} missing")
+        self.render_current()
+        self._show_toast(f"✓ Rescan complete — {len(self.entries)} keys", bg="#16a34a")
+        self.ai_status.configure(text="")
+
+    # ---- Ignore button highlight (when Claude classifies key as non-translation) ----
+    def _highlight_ignore_suggestion(self) -> None:
+        style = ttk.Style(self)
+        style.configure("Highlight.Ignore.TButton", foreground="#b45309")
+        try:
+            self.ignore_btn.configure(style="Highlight.Ignore.TButton")
+        except Exception:
+            pass
+        self._show_toast(
+            "🤔 Claude suggests: probably not a translation key — consider Ignore",
+            bg="#f59e0b",
+            duration_ms=3500,
+        )
+
+    def _reset_ignore_highlight(self) -> None:
+        try:
+            self.ignore_btn.configure(style="TButton")
+        except Exception:
+            pass
+
+    # ---- Auto-prefetch (batch AI suggestions in background) ----
+    def _on_auto_toggle(self) -> None:
+        if self._auto_var and self._auto_var.get():
+            self._start_prefetch()
+        else:
+            self._stop_prefetch()
+
+    def _start_prefetch(self) -> None:
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            return
+        self._prefetch_stop.clear()
+        self._prefetch_thread = threading.Thread(target=self._prefetch_worker, daemon=True)
+        self._prefetch_thread.start()
+
+    def _stop_prefetch(self) -> None:
+        self._prefetch_stop.set()
+        self.ai_status.configure(text="Auto-prefetch stopped")
+
+    def _maybe_kick_prefetch(self) -> None:
+        """Called after navigation — ensures the worker is still running if auto is on."""
+        if self._auto_var and self._auto_var.get():
+            self._start_prefetch()
+
+    # ---- Auto save & next -----------------------------------------------
+    def _on_auto_advance_toggle(self) -> None:
+        if self._auto_advance_var and self._auto_advance_var.get():
+            # Toggling on while an entry is already displayed — maybe start the countdown now.
+            self._maybe_start_auto_advance()
+        else:
+            self._cancel_auto_advance("auto-advance disabled")
+
+    def _cancel_auto_advance(self, reason: str = "") -> None:
+        if self._auto_advance_after_id is not None:
+            try:
+                self.after_cancel(self._auto_advance_after_id)
+            except Exception:
+                pass
+            self._auto_advance_after_id = None
+        if self._auto_advance_countdown_id is not None:
+            try:
+                self.after_cancel(self._auto_advance_countdown_id)
+            except Exception:
+                pass
+            self._auto_advance_countdown_id = None
+        if reason:
+            self.ai_status.configure(text=reason)
+
+    def _maybe_start_auto_advance(self) -> None:
+        """Schedule an auto action after N seconds, based on the current entry.
+
+        Auto-action decision tree (when the checkbox is on and the user hasn't typed):
+          - vendor-only key with no linked fork → auto-SKIP (rescan after linking will pick it up)
+          - Claude classifies as non-translation → auto-IGNORE (marked in DB, never re-proposed)
+          - AI suggestion loaded + EN/FR populated → auto-SAVE & NEXT
+          - else nothing to auto (idle)
+
+        When the end of the list is reached, save_and_next simply stops advancing,
+        letting the user review any remaining entries manually.
+        """
+        self._cancel_auto_advance()
+        if not (self._auto_advance_var and self._auto_advance_var.get()):
+            return
+        if not self.entries:
+            return
+
+        entry = self.entries[self.index]
+        key = entry["key"]
+
+        # Respect the user's in-progress edits.
+        if key in self._drafts:
+            return
+
+        cached = self._ai_cache.get(key)
+
+        # 1. Vendor-only key without a linked fork → skip (we cannot save safely).
+        target = self._resolve_target_project(entry)
+        if target == self.project_root and self._entry_only_in_vendor(entry):
+            self._auto_advance_action = "skip"
+            tpl = "⏭ Auto-skip (vendor-only, link the package to save) in {s}s… (any action cancels)"
+            self._auto_advance_step(self._auto_advance_seconds, tpl)
+            return
+
+        # 2. Classified non-translation → ignore.
+        if cached and cached.get("is_translation_key") is False:
+            self._auto_advance_action = "ignore"
+            tpl = "⊘ Auto-ignore (not a translation key) in {s}s… (any action cancels)"
+            self._auto_advance_step(self._auto_advance_seconds, tpl)
+            return
+
+        # 3. Suggestion ready and fields filled → save.
+        if cached and (self.en_var.get().strip() or self.fr_var.get().strip()):
+            self._auto_advance_action = "save"
+            tpl = "🤖 Auto save & next in {s}s… (type anything to cancel)"
+            self._auto_advance_step(self._auto_advance_seconds, tpl)
+            return
+
+        # Otherwise nothing to auto — wait for a cached suggestion to arrive.
+
+    def _auto_advance_step(self, remaining: int, text_template: str) -> None:
+        if remaining <= 0:
+            self._auto_advance_after_id = None
+            self._auto_advance_countdown_id = None
+            if not (self._auto_advance_var and self._auto_advance_var.get()):
+                return
+            if not self.entries:
+                return
+            action = self._auto_advance_action
+            self._auto_advance_action = None
+            if action == "save":
+                self.save_and_next()
+            elif action == "ignore":
+                self.ignore()
+            elif action == "skip":
+                self.skip()
+            return
+        self.ai_status.configure(text=text_template.format(s=remaining))
+        self._auto_advance_countdown_id = self.after(
+            1000,
+            lambda r=remaining - 1, t=text_template: self._auto_advance_step(r, t),
+        )
+
+    def _prefetch_worker(self) -> None:
+        """Walk through entries starting from `self.index + 1`, filling `_ai_cache`.
+        Stops if the user toggles auto off or closes the window."""
+        while not self._prefetch_stop.is_set():
+            # Pick the next uncached entry forward of current index.
+            target: Optional[dict] = None
+            for i in range(self.index + 1, len(self.entries)):
+                e = self.entries[i]
+                if e["key"] not in self._ai_cache:
+                    target = e
+                    break
+            if target is None:
+                self.after(0, lambda: self.ai_status.configure(text="Auto-prefetch: all ahead cached"))
+                return
+
+            self.after(0, lambda k=target["key"]: self.ai_status.configure(
+                text=f"Auto-prefetch: asking Claude about {k}…"
+            ))
+
+            try:
+                wider = ai_module.read_wider_context(
+                    self.project_root,
+                    target.get("file", ""),
+                    target.get("line"),
+                    radius=20,
+                )
+                result = ai_module.suggest(
+                    key=target["key"],
+                    code_context=target.get("context", ""),
+                    file_path=target.get("file", ""),
+                    wider_context=wider,
+                    timeout=90,
+                )
+                self._ai_cache[target["key"]] = result
+                self.after(0, self._on_prefetch_item_done, target["key"])
+            except Exception as exc:  # keep the worker alive across failures
+                self.after(0, lambda msg=str(exc): self.ai_status.configure(text=f"Prefetch error: {msg[:80]}"))
+                # Small backoff to avoid hammering on persistent failure.
+                if self._prefetch_stop.wait(5):
+                    return
+
+    def _on_prefetch_item_done(self, key: str) -> None:
+        cached = len(self._ai_cache)
+        self.ai_status.configure(text=f"Auto-prefetch: {cached} key(s) cached")
+        # If the cached key matches what's currently shown, and the user hasn't typed anything,
+        # auto-fill the fields so they see the suggestion immediately.
+        if self.entries and self.entries[self.index]["key"] == key:
+            if not self.en_var.get().strip() and not self.fr_var.get().strip():
+                self.render_current()  # will also kick the countdown if enabled
+            else:
+                self._maybe_start_auto_advance()
+
+    def save_and_close(self) -> None:
+        """Flush ALL drafts (including the current entry) to JSON + DB, then close."""
+        # Capture whatever is in the fields right now.
+        self._capture_draft_if_dirty()
+
+        # Stop auto-prefetch before heavy writes.
+        self._stop_prefetch()
+
+        # Group drafts per target so we write each project's lang files exactly once.
+        per_target: dict[Path, list[tuple[str, str, str]]] = {}  # target -> [(key, en, fr)]
+        flushed: list[tuple[str, list[str], Path]] = []
+        entry_by_key = {e["key"]: e for e in self.entries}
+        skipped_vendor_only: list[tuple[str, list[str]]] = []  # key, vendor_pkgs
+
+        for key, draft in list(self._drafts.items()):
+            en = draft.get("en", "").strip()
+            fr = draft.get("fr", "").strip()
+            if not en and not fr:
+                continue
+            entry = entry_by_key.get(key)
+            if not entry:
+                # Stale draft (key no longer in the scan): write to main project.
+                target = self.project_root
+            else:
+                target = self._resolve_target_project(entry)
+                if target == self.project_root:
+                    vendor_pkgs = self._entry_only_in_vendor(entry)
+                    if vendor_pkgs:
+                        # Refuse to pollute the main project — queue a warning instead.
+                        skipped_vendor_only.append((key, vendor_pkgs))
+                        continue
+            self._ensure_target_loaded(target)
+            per_target.setdefault(target, []).append((key, en, fr))
+
+        if skipped_vendor_only and not per_target:
+            # Everything was vendor-only → nothing safe to save, show the guard once.
+            pkg_set = sorted({p for _, pkgs in skipped_vendor_only for p in pkgs})
+            self._show_link_required_dialog(pkg_set)
+            return
+
+        if not per_target:
+            if not messagebox.askokcancel(
+                "Nothing to save",
+                "No drafts have text to save. Close without saving?",
+            ):
+                return
+            self.destroy()
+            return
+
+        try:
+            for target, items in per_target.items():
+                store = self._lang_cache[target]
+                for key, en, fr in items:
+                    if en:
+                        store["en"][key] = en
+                    if fr:
+                        store["fr"][key] = fr
+                    locales = [loc for loc, val in [("EN", en), ("FR", fr)] if val]
+                    flushed.append((key, locales, target))
+                save_lang(store["en_path"], store["en"], store["en_original"])
+                save_lang(store["fr_path"], store["fr"], store["fr_original"])
+        except Exception as exc:
+            messagebox.showerror("Save error", str(exc))
+            return
+
+        # DB updates for every flushed key (fire-and-forget, grouped).
+        for key, locales, _target in flushed:
+            self._mark_db_async(key, "fixed", [l.lower() for l in locales])
+        self._session["saved"] += len(flushed)
+        self._refresh_footer()
+
+        # Let fire-and-forget subprocesses start before the app quits.
+        self.update_idletasks()
+        time.sleep(0.3)
+
+        summary = "\n".join(
+            f"  • {k}  [{'+'.join(locs)}]  → {self._target_label(t)}"
+            for k, locs, t in flushed[:20]
+        )
+        if len(flushed) > 20:
+            summary += f"\n  … and {len(flushed) - 20} more"
+
+        touched_files: list[str] = []
+        for target in per_target.keys():
+            store = self._lang_cache[target]
+            touched_files.append(f"  • {store['en_path']}")
+            touched_files.append(f"  • {store['fr_path']}")
+
+        skipped_lines = ""
+        if skipped_vendor_only:
+            skipped_lines = (
+                "\n\n⚠ Skipped (vendor-only — link the package and retry):\n"
+                + "\n".join(f"  • {k}   ({', '.join(pkgs)})" for k, pkgs in skipped_vendor_only[:10])
+            )
+            if len(skipped_vendor_only) > 10:
+                skipped_lines += f"\n  … and {len(skipped_vendor_only) - 10} more"
+
+        messagebox.showinfo(
+            "Saved",
+            f"Saved {len(flushed)} key(s) in this session:\n\n{summary}\n\n"
+            f"Files updated:\n" + "\n".join(touched_files)
+            + skipped_lines + "\n\n"
+            f"Session totals:\n"
+            f"  ✓ {self._session['saved']} saved\n"
+            f"  ⊘ {self._session['ignored']} ignored\n"
+            f"  → {self._session['skipped']} skipped",
+        )
+        self.destroy()
+
+    def skip(self) -> None:
+        self._cancel_auto_advance()
+        entry = self.entries[self.index] if self.entries else None
+        if entry:
+            self._show_toast(f"→ Skipped  {entry['key']}", bg="#64748b")
+        self._session["skipped"] += 1
+        self._refresh_footer()
+        self.status_label.configure(text="Skipped")
+        self.next()
+
+    def ignore(self) -> None:
+        self._cancel_auto_advance()
+        entry = self.entries[self.index]
+        self.ignored.add(entry["key"])
+        self._persist_ignored()
+
+        # Mark all DB rows for this key as ignored (no --locale filter → both EN and FR).
+        self._mark_db_async(entry["key"], "ignored", [])
+        self._session["ignored"] += 1
+        self._refresh_footer()
+
+        self._show_toast(
+            f"⊘ Ignored  {entry['key']}  ·  DB row marked",
+            bg="#d97706",
+        )
+        self.status_label.configure(
+            text=f"Ignored {entry['key']} · DB row marked · pending-ignore={len(self.ignored)}"
+        )
+        self.next()
+
+    def next(self) -> None:
+        self._cancel_auto_advance()
+        self._capture_draft_if_dirty()
+        if self.index < len(self.entries) - 1:
+            self.index += 1
+            self.render_current()
+            self._maybe_kick_prefetch()
+        else:
+            # End of list reached — turn off auto mode so the user can review manually.
+            if self._auto_advance_var and self._auto_advance_var.get():
+                self._auto_advance_var.set(False)
+                self._show_toast(
+                    "✅ Reached end of list — auto-advance turned off for review",
+                    bg="#0f766e",
+                    duration_ms=4000,
+                )
+            self.status_label.configure(text="End of list — review remaining entries manually.")
+            self.ai_status.configure(text="")
+
+    def prev(self) -> None:
+        self._cancel_auto_advance()
+        self._capture_draft_if_dirty()
+        if self.index > 0:
+            self.index -= 1
+            self.render_current()
+
+    # ---- helpers ----------------------------------------------------------
+    def _show_toast(self, text: str, bg: str, fg: str = "#ffffff", duration_ms: int = 2200) -> None:
+        """Flash a coloured banner that auto-clears after `duration_ms`."""
+        if self._toast_after_id is not None:
+            try:
+                self.after_cancel(self._toast_after_id)
+            except Exception:
+                pass
+            self._toast_after_id = None
+
+        self.toast.configure(text=text, background=bg, foreground=fg)
+        self._toast_after_id = self.after(duration_ms, self._clear_toast)
+
+    def _clear_toast(self) -> None:
+        default_bg = self.cget("background")
+        self.toast.configure(text="", background=default_bg, foreground=default_bg)
+        self._toast_after_id = None
+
+    def _file_mtime(self, path: Path) -> str:
+        try:
+            ts = path.stat().st_mtime
+            return datetime.fromtimestamp(ts).strftime("%H:%M:%S")
+        except FileNotFoundError:
+            return "—"
+
+    def _refresh_footer(self) -> None:
+        s = self._session
+        counters = f"Session: ✓ {s['saved']} saved  ⊘ {s['ignored']} ignored  → {s['skipped']} skipped"
+        self.session_label.configure(text=counters)
+
+        en_m = self._file_mtime(self.en_path)
+        fr_m = self._file_mtime(self.fr_path)
+        self.files_label.configure(
+            text=f"en.json @ {en_m}   fr.json @ {fr_m}"
+        )
+
+    def _mark_db_async(self, key: str, status: str, locales: list[str]) -> None:
+        """Fire-and-forget artisan call to update the missing_translations table.
+        UI stays snappy; errors are silent (by design — JSON is source of truth)."""
+        cmd = ["php", "artisan", "app:mark-missing-translation", key, f"--status={status}"]
+        for loc in locales:
+            cmd.append(f"--locale={loc}")
+
+        creationflags = 0
+        if sys.platform == "win32":
+            # CREATE_NO_WINDOW = 0x08000000 — avoids a console flash per call.
+            creationflags = 0x08000000
+
+        # Prune finished processes to keep the buffer bounded.
+        self._async_procs = [p for p in self._async_procs if p.poll() is None]
+        proc = subprocess.Popen(
+            cmd,
+            cwd=str(self.project_root),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            creationflags=creationflags,
+        )
+        self._async_procs.append(proc)
+
+    def _open_file_in_editor(self) -> None:
+        entry = self.entries[self.index]
+        rel = entry.get("file")
+        if not rel:
+            return
+        absolute = self.project_root / rel.replace("\\", os.sep).replace("/", os.sep)
+        if not absolute.exists():
+            messagebox.showinfo("File not found", f"{absolute}")
+            return
+        line = entry.get("line") or 1
+        # Try VS Code first (via PATH), fall back to OS default.
+        try:
+            subprocess.Popen(["code", "-g", f"{absolute}:{line}"])
+        except FileNotFoundError:
+            try:
+                os.startfile(str(absolute))  # type: ignore[attr-defined]
+            except Exception as exc:
+                messagebox.showerror("Open failed", str(exc))
+
+
+# --------------------------------------------------------------------------- #
+# Entry point
+# --------------------------------------------------------------------------- #
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.strip())
+    parser.add_argument("json_file", nargs="?", type=Path,
+                        help="Existing JSON from analyzer --json (optional).")
+    parser.add_argument("--project", type=Path, default=None,
+                        help="Project root (auto-detected by default).")
+    args = parser.parse_args()
+
+    start = Path(__file__).resolve().parent
+    project_root = args.project or find_project_root(start) or find_project_root(Path.cwd())
+    if not project_root:
+        print("Cannot locate project root (no composer.json + resources/lang found).", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        payload = load_missing_payload(args.json_file, project_root)
+    except Exception as exc:
+        print(f"Failed to load missing keys: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    entries = build_entries(payload)
+    app = TranslatorApp(entries, project_root)
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Large upgrade to the translation tooling shipped by the utils package: a more accurate missing-key analyzer, real triage state in the DB, and a desktop GUI (Python/Tkinter) that walks through missing keys one by one with optional AI assistance.

Everything ships under `condoedge/utils` so any Laravel app that depends on the package (SISC, Coolecto, future apps) gets it for free.

## What's new

### Analyzer (`app:missing-translation-analyzer-command`)
- Data-driven `TRANSLATION_FUNCTIONS` list: adding a new helper or JS call is now a one-liner
- New detection patterns: array values (`=> 'ns.key'`), `throwValidationError` 2nd arg, PHP 8 named args, Vue `$t` / `i18n.t`, `v-t` directive
- Narrowed match context (40 chars before the key, word-boundary): no more false rejections from `->revalidate()` matching `validate(`
- Dynamic-prefix detection auto-skips keys whose namespace is used in interpolated calls (`__('events.' . $x)`)
- Literal-grep second pass rescues keys referenced by patterns the regex can't parse — cut `--check-obsolete` false positives ~50% on SISC
- New flags: `--locale=*`, `--include-plain-text`, `--universal-detection` (UI-scoped), `--check-empty-values`, `--check-obsolete`, `--diff-locales`, `--include-triaged`
- Dynamic locales from `config('app.supported_locales')`
- Optional linked packages as extra scan roots via `storage/app/translator_linked_packages.json`

### Triage state
- New columns on `missing_translations`: `locale`, `hit_count`, `last_seen_at`
- Composite unique key `(translation_key, locale)`
- Model observer invalidates the `TrackingTranslator` cache when `fixed_at` / `ignored_at` change
- Default scan hides rows already fixed/ignored (`--include-triaged` to override)

### New artisan commands
- `app:mark-missing-translation {keys*} --status=fixed|ignored|reset --locale=*`
- `app:translator-packages list|add|remove|clear`
- `app:translator` — launch the desktop GUI (detaches correctly on Windows via `start /B`, uses `pythonw` by default so no console flash)

### Desktop translator GUI (`tools/translator/`)
Python + tkinter, zero external deps.
- Prev / Next / Save & Next / Save & Close / Skip / Ignore
- Toasts, session counters, live mtime of the lang files, linked-packages manager
- Writes go to the right project: keys whose source lives in a linked local package land in that package's `resources/lang/*.json`, never the main app's
- Guard: vendor-only keys without a linked fork get a "link the package first" dialog instead of polluting main
- Round-trip byte-identical on unchanged data; new keys inserted at the alphabetical position in the existing file
- Save & Close flushes every typed draft, even across multiple target projects in one session

### AI suggestions (optional)
- Uses `claude --print` CLI when available — no API key needed, cost goes through each dev's own Claude Max subscription
- Defaults to Haiku 4.5 for economy (override via `SISC_TRANSLATOR_MODEL`)
- Concise system prompt with the SISC glossary (Scout / Volunteer / Person, Quebec FR, keep "brevet"/"inscription"/"camp")
- Claude classifies each key: when the identifier looks like an icon name, date format, HTML attribute or DB column, the Ignore button is highlighted
- Auto-prefetch in a background thread; cached suggestions populate the fields instantly on navigation
- Auto save & next: 3 s countdown that auto-saves translations, auto-ignores non-translation keys, or auto-skips vendor-only keys; stops cleanly at the end of the list for review

## Test plan
- [ ] `php artisan migrate` picks up the new `2026_04_22_000001_…` migration
- [ ] `php artisan app:missing-translation-analyzer-command` runs and writes `storage/app/translation_keys.json`
- [ ] `--check-obsolete`, `--check-empty-values`, `--diff-locales` each produce sensible output
- [ ] `app:mark-missing-translation foo.bar --status=fixed --locale=en` marks the row correctly
- [ ] `app:translator-packages add/remove/list/clear` round-trips via `storage/app/translator_linked_packages.json`
- [ ] `app:translator` launches the GUI (detaches on Windows, stays attached with `--foreground` for debugging)
- [ ] GUI Save writes to main project's `en.json`/`fr.json`
- [ ] GUI Save writes to the linked package's `resources/lang/*.json` when the key lives there
- [ ] GUI refuses to save vendor-only keys (dialog guidance)
- [ ] AI Suggest button disabled when `claude` CLI is not on PATH
- [ ] AI Suggest returns JSON and populates the fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)