### PR TITLE
Remove decorative chrome from _ModalHeader

### DIFF
--- a/src/Helpers/elements/styled.php
+++ b/src/Helpers/elements/styled.php
@@ -146,7 +146,7 @@ if (!function_exists('_ModalHeader')) {
         return _FlexBetween(
             $els,
         )
-            ->class('justify-between items-start border-b border-gray-200 py-4 px-6 rounded-t-xl bg-white ModalHeader');
+            ->class('justify-between items-start pt-8 pb-4 px-6 ModalHeader');
     }
 }
 


### PR DESCRIPTION
## Summary
- `_ModalHeader` was rendering as a card-like header with its own border-bottom, top-rounded corners and white background. When nested inside a modal that already provides its own framing, this created a visible mismatch: the inner header's rounded corners didn't line up with the modal's, and the bottom border looked like an unintended separator.
- Drop `border-b border-gray-200`, `rounded-t-xl` and `bg-white` from the helper. Padding goes from `py-4` to `pt-8 pb-4` to match the breathing space of the standard Kompo `Modal::header()`.

## Test plan
- [ ] Open any modal that uses `_ModalHeader` (e.g. the onboarding flows in the consumer apps) and confirm the title section blends with the modal body.
- [ ] No regression on standalone uses of the helper outside a modal frame.